### PR TITLE
pegasus: add an option to use rocksdb to reduce intrusive modifications

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -48,7 +48,6 @@ if(CCACHE_FOUND)
   message("use ccache to speed up compilation")
 endif(CCACHE_FOUND)
 
-add_definitions(-DPEGASUS)
 option(WITH_JEMALLOC "build with JeMalloc" OFF)
 if(MSVC)
   include(${CMAKE_CURRENT_SOURCE_DIR}/thirdparty.inc)
@@ -65,7 +64,7 @@ else()
     endif()
   endif()
 
-  option(WITH_SNAPPY "build with SNAPPY" ON)
+  option(WITH_SNAPPY "build with SNAPPY" OFF)
   if(WITH_SNAPPY)
     find_package(snappy REQUIRED)
     add_definitions(-DSNAPPY)
@@ -73,7 +72,7 @@ else()
     list(APPEND THIRDPARTY_LIBS ${SNAPPY_LIBRARIES})
   endif()
 
-  option(WITH_ZLIB "build with zlib" ON)
+  option(WITH_ZLIB "build with zlib" OFF)
   if(WITH_ZLIB)
     find_package(zlib REQUIRED)
     add_definitions(-DZLIB)
@@ -81,7 +80,7 @@ else()
     list(APPEND THIRDPARTY_LIBS ${ZLIB_LIBRARIES})
   endif()
 
-  option(WITH_BZ2 "build with bzip2" ON)
+  option(WITH_BZ2 "build with bzip2" OFF)
   if(WITH_BZ2)
     find_package(bzip2 REQUIRED)
     add_definitions(-DBZIP2)
@@ -137,7 +136,7 @@ if(NOT WIN32)
   string(STRIP "${ROCKSDB_VERSION_MAJOR}" ROCKSDB_VERSION_MAJOR)
 endif()
 
-option(WITH_MD_LIBRARY "build with MD" OFF)
+option(WITH_MD_LIBRARY "build with MD" ON)
 if(WIN32 AND MSVC)
   if(WITH_MD_LIBRARY)
     set(RUNTIME_LIBRARY "MD")
@@ -600,23 +599,23 @@ endif()
 
 set(ROCKSDB_STATIC_LIB rocksdb${ARTIFACT_SUFFIX})
 set(ROCKSDB_SHARED_LIB rocksdb-shared${ARTIFACT_SUFFIX})
-set(ROCKSDB_IMPORT_LIB ${ROCKSDB_STATIC_LIB})
+set(ROCKSDB_IMPORT_LIB ${ROCKSDB_SHARED_LIB})
 if(WIN32)
   set(SYSTEM_LIBS ${SYSTEM_LIBS} Shlwapi.lib Rpcrt4.lib)
   set(LIBS ${ROCKSDB_STATIC_LIB} ${THIRDPARTY_LIBS} ${SYSTEM_LIBS})
 else()
-  set(SYSTEM_LIBS ${CMAKE_THREAD_LIBS_INIT} rt)
-  set(LIBS ${ROCKSDB_STATIC_LIB} ${THIRDPARTY_LIBS} ${SYSTEM_LIBS})
+  set(SYSTEM_LIBS ${CMAKE_THREAD_LIBS_INIT})
+  set(LIBS ${ROCKSDB_SHARED_LIB} ${THIRDPARTY_LIBS} ${SYSTEM_LIBS})
 
-#  add_library(${ROCKSDB_SHARED_LIB} SHARED ${SOURCES})
-#  target_link_libraries(${ROCKSDB_SHARED_LIB}
-#    ${THIRDPARTY_LIBS} ${SYSTEM_LIBS})
-#  set_target_properties(${ROCKSDB_SHARED_LIB} PROPERTIES
-#                        LINKER_LANGUAGE CXX
-#                        VERSION ${ROCKSDB_VERSION}
-#                        SOVERSION ${ROCKSDB_VERSION_MAJOR}
-#                        CXX_STANDARD 11
-#                        OUTPUT_NAME "rocksdb")
+  add_library(${ROCKSDB_SHARED_LIB} SHARED ${SOURCES})
+  target_link_libraries(${ROCKSDB_SHARED_LIB}
+    ${THIRDPARTY_LIBS} ${SYSTEM_LIBS})
+  set_target_properties(${ROCKSDB_SHARED_LIB} PROPERTIES
+                        LINKER_LANGUAGE CXX
+                        VERSION ${ROCKSDB_VERSION}
+                        SOVERSION ${ROCKSDB_VERSION_MAJOR}
+                        CXX_STANDARD 11
+                        OUTPUT_NAME "rocksdb")
 endif()
 
 option(WITH_LIBRADOS "Build with librados" OFF)
@@ -690,14 +689,14 @@ if(NOT WIN32 OR ROCKSDB_INSTALL_ON_WINDOWS)
     INCLUDES DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}"
   )
 
-#  install(
-#    TARGETS ${ROCKSDB_SHARED_LIB}
-#    EXPORT RocksDBTargets
-#    COMPONENT runtime
-#    RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}"
-#    LIBRARY DESTINATION "${CMAKE_INSTALL_LIBDIR}"
-#    INCLUDES DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}"
-#  )
+  install(
+    TARGETS ${ROCKSDB_SHARED_LIB}
+    EXPORT RocksDBTargets
+    COMPONENT runtime
+    RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}"
+    LIBRARY DESTINATION "${CMAKE_INSTALL_LIBDIR}"
+    INCLUDES DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}"
+  )
 
   install(
     EXPORT RocksDBTargets
@@ -715,7 +714,7 @@ if(NOT WIN32 OR ROCKSDB_INSTALL_ON_WINDOWS)
   )
 endif()
 
-option(WITH_TESTS "build with tests" OFF)
+option(WITH_TESTS "build with tests" ON)
 if(WITH_TESTS)
   set(TESTS
         cache/cache_test.cc

--- a/db/c_test.c
+++ b/db/c_test.c
@@ -535,10 +535,6 @@ int main(int argc, char** argv) {
 
   StartPhase("checkpoint");
   {
-    rocksdb_put(db, woptions, "foo", 3, "hello", 5, &err);    // PEGASUS: avoid memtable to be empty.
-                                                              // empty memtable will skip create checkpoint in pegasus
-    CheckNoError(err);
-
     rocksdb_destroy_db(options, dbcheckpointname, &err);
     CheckNoError(err);
 
@@ -719,9 +715,8 @@ int main(int argc, char** argv) {
     rocksdb_writebatch_destroy(wb);
   }
 
-  StartPhase("writebatch_savepoint");  // PEGASUS: not support empty batch
+  StartPhase("writebatch_savepoint");
   {
-    /*
     rocksdb_writebatch_t* wb = rocksdb_writebatch_create();
     rocksdb_writebatch_set_save_point(wb);
     rocksdb_writebatch_set_save_point(wb);
@@ -738,7 +733,6 @@ int main(int argc, char** argv) {
     CheckNoError(err);
     CheckGet(db, roptions, "zap", NULL);
     rocksdb_writebatch_destroy(wb);
-    */
   }
 
   StartPhase("writebatch_rep");
@@ -826,9 +820,8 @@ int main(int argc, char** argv) {
     rocksdb_writebatch_wi_destroy(wb);
   }
 
-  StartPhase("writebatch_wi_savepoint");  // PEGASUS: not support empty batch
+  StartPhase("writebatch_wi_savepoint");
   {
-    /*
     rocksdb_writebatch_wi_t* wb = rocksdb_writebatch_wi_create(0, 1);
     rocksdb_writebatch_wi_set_save_point(wb);
     const char* k_list[2] = {"z", "ap"};
@@ -842,7 +835,6 @@ int main(int argc, char** argv) {
     CheckNoError(err);
     CheckGet(db, roptions, "zap", NULL);
     rocksdb_writebatch_wi_destroy(wb);
-    */
   }
 
   StartPhase("iter");

--- a/db/column_family.cc
+++ b/db/column_family.cc
@@ -1006,7 +1006,7 @@ ColumnFamilySet::ColumnFamilySet(const std::string& dbname,
                                  WriteBufferManager* write_buffer_manager,
                                  WriteController* write_controller)
     : max_column_family_(0),
-      value_schema_version_(db_options->default_value_schema_version),
+      pegasus_data_version_(db_options->pegasus_data_version),
       last_manual_compact_finish_time_(0),
       dummy_cfd_(new ColumnFamilyData(0, "", nullptr, nullptr, nullptr,
                                       ColumnFamilyOptions(), *db_options,
@@ -1074,18 +1074,18 @@ size_t ColumnFamilySet::NumberOfColumnFamilies() const {
   return column_families_.size();
 }
 
-uint32_t ColumnFamilySet::GetValueSchemaVersion() { return value_schema_version_; }
+uint32_t ColumnFamilySet::GetPegasusDataVersion() const { return pegasus_data_version_; }
 
-void ColumnFamilySet::SetValueSchemaVersion(uint32_t version) {
-    value_schema_version_ = version;
+void ColumnFamilySet::SetPegasusDataVersion(uint32_t version) {
+  pegasus_data_version_ = version;
 }
 
-uint64_t ColumnFamilySet::GetLastManualCompactFinishTime() {
+uint64_t ColumnFamilySet::GetLastManualCompactFinishTime() const {
   return last_manual_compact_finish_time_;
 }
 
 void ColumnFamilySet::SetLastManualCompactFinishTime(uint64_t ms) {
-    last_manual_compact_finish_time_ = ms;
+  last_manual_compact_finish_time_ = ms;
 }
 
 // under a DB mutex AND write thread

--- a/db/column_family.h
+++ b/db/column_family.h
@@ -482,10 +482,9 @@ class ColumnFamilySet {
   uint32_t GetMaxColumnFamily();
   void UpdateMaxColumnFamily(uint32_t new_max_column_family);
   size_t NumberOfColumnFamilies() const;
-  // Get and set value schema version.
-  uint32_t GetValueSchemaVersion();
-  void SetValueSchemaVersion(uint32_t version);
-  uint64_t GetLastManualCompactFinishTime();
+  uint32_t GetPegasusDataVersion() const;
+  void SetPegasusDataVersion(uint32_t version);
+  uint64_t GetLastManualCompactFinishTime() const;
   void SetLastManualCompactFinishTime(uint64_t ms);
   ColumnFamilyData* CreateColumnFamily(const std::string& name, uint32_t id,
                                        Version* dummy_version,
@@ -517,7 +516,7 @@ class ColumnFamilySet {
   std::unordered_map<uint32_t, ColumnFamilyData*> column_family_data_;
 
   uint32_t max_column_family_;
-  uint32_t value_schema_version_;
+  uint32_t pegasus_data_version_;
   uint64_t last_manual_compact_finish_time_;
   ColumnFamilyData* dummy_cfd_;
   // We don't hold the refcount here, since default column family always exists

--- a/db/column_family_test.cc
+++ b/db/column_family_test.cc
@@ -740,7 +740,7 @@ TEST_F(ColumnFamilyTest, BulkAddDrop) {
   ASSERT_TRUE(families == std::vector<std::string>({"default"}));
 }
 
-TEST_F(ColumnFamilyTest, DISABLED_DropTest) {
+TEST_F(ColumnFamilyTest, DropTest) {
   // first iteration - dont reopen DB before dropping
   // second iteration - reopen DB before dropping
   for (int iter = 0; iter < 2; ++iter) {
@@ -764,7 +764,7 @@ TEST_F(ColumnFamilyTest, DISABLED_DropTest) {
   }
 }
 
-TEST_F(ColumnFamilyTest, DISABLED_WriteBatchFailure) {
+TEST_F(ColumnFamilyTest, WriteBatchFailure) {
   Open();
   CreateColumnFamiliesAndReopen({"one", "two"});
   WriteBatch batch;
@@ -782,7 +782,7 @@ TEST_F(ColumnFamilyTest, DISABLED_WriteBatchFailure) {
   Close();
 }
 
-TEST_F(ColumnFamilyTest, DISABLED_ReadWrite) {
+TEST_F(ColumnFamilyTest, ReadWrite) {
   Open();
   CreateColumnFamiliesAndReopen({"one", "two"});
   ASSERT_OK(Put(0, "foo", "v1"));
@@ -806,7 +806,7 @@ TEST_F(ColumnFamilyTest, DISABLED_ReadWrite) {
   Close();
 }
 
-TEST_F(ColumnFamilyTest, DISABLED_IgnoreRecoveredLog) {
+TEST_F(ColumnFamilyTest, IgnoreRecoveredLog) {
   std::string backup_logs = dbname_ + "/backup_logs";
 
   // delete old files in backup_logs directory
@@ -884,12 +884,12 @@ TEST_F(ColumnFamilyTest, DISABLED_IgnoreRecoveredLog) {
 #ifndef ROCKSDB_LITE  // TEST functions used are not supported
 TEST_F(ColumnFamilyTest, FlushTest) {
   Open();
-//  CreateColumnFamiliesAndReopen({"one", "two"});
+  CreateColumnFamiliesAndReopen({"one", "two"});
   ASSERT_OK(Put(0, "foo", "v1"));
   ASSERT_OK(Put(0, "bar", "v2"));
-//  ASSERT_OK(Put(1, "mirko", "v3"));
+  ASSERT_OK(Put(1, "mirko", "v3"));
   ASSERT_OK(Put(0, "foo", "v2"));
-//  ASSERT_OK(Put(2, "fodor", "v5"));
+  ASSERT_OK(Put(2, "fodor", "v5"));
 
   for (int j = 0; j < 2; j++) {
     ReadOptions ro;
@@ -899,13 +899,13 @@ TEST_F(ColumnFamilyTest, FlushTest) {
       ASSERT_OK(db_->NewIterators(ro, handles_, &iterators));
     }
 
-    for (int i = 0; i < 1; ++i) {
+    for (int i = 0; i < 3; ++i) {
       uint64_t max_total_in_memory_state =
           MaxTotalInMemoryState();
       Flush(i);
       AssertMaxTotalInMemoryState(max_total_in_memory_state);
     }
-//    ASSERT_OK(Put(1, "foofoo", "bar"));
+    ASSERT_OK(Put(1, "foofoo", "bar"));
     ASSERT_OK(Put(0, "foofoo", "bar"));
 
     for (auto* it : iterators) {
@@ -917,11 +917,11 @@ TEST_F(ColumnFamilyTest, FlushTest) {
   for (int iter = 0; iter <= 2; ++iter) {
     ASSERT_EQ("v2", Get(0, "foo"));
     ASSERT_EQ("v2", Get(0, "bar"));
-//    ASSERT_EQ("v3", Get(1, "mirko"));
-//    ASSERT_EQ("v5", Get(2, "fodor"));
+    ASSERT_EQ("v3", Get(1, "mirko"));
+    ASSERT_EQ("v5", Get(2, "fodor"));
     ASSERT_EQ("NOT_FOUND", Get(0, "fodor"));
-//    ASSERT_EQ("NOT_FOUND", Get(1, "fodor"));
-//    ASSERT_EQ("NOT_FOUND", Get(2, "foo"));
+    ASSERT_EQ("NOT_FOUND", Get(1, "fodor"));
+    ASSERT_EQ("NOT_FOUND", Get(2, "foo"));
     if (iter <= 1) {
       Reopen();
     }
@@ -930,7 +930,7 @@ TEST_F(ColumnFamilyTest, FlushTest) {
 }
 
 // Makes sure that obsolete log files get deleted
-TEST_F(ColumnFamilyTest, DISABLED_LogDeletionTest) {
+TEST_F(ColumnFamilyTest, LogDeletionTest) {
   db_options_.max_total_wal_size = std::numeric_limits<uint64_t>::max();
   column_family_options_.arena_block_size = 4 * 1024;
   column_family_options_.write_buffer_size = 128000;  // 128KB
@@ -998,7 +998,7 @@ TEST_F(ColumnFamilyTest, DISABLED_LogDeletionTest) {
 }
 #endif  // !ROCKSDB_LITE
 
-TEST_F(ColumnFamilyTest, DISABLED_CrashAfterFlush) {
+TEST_F(ColumnFamilyTest, CrashAfterFlush) {
   std::unique_ptr<FaultInjectionTestEnv> fault_env(
       new FaultInjectionTestEnv(env_));
   db_options_.env = fault_env.get();
@@ -1038,7 +1038,7 @@ TEST_F(ColumnFamilyTest, OpenNonexistentColumnFamily) {
 
 #ifndef ROCKSDB_LITE  // WaitForFlush() is not supported
 // Makes sure that obsolete log files get deleted
-TEST_F(ColumnFamilyTest, DISABLED_DifferentWriteBufferSizes) {
+TEST_F(ColumnFamilyTest, DifferentWriteBufferSizes) {
   // disable flushing stale column families
   db_options_.max_total_wal_size = std::numeric_limits<uint64_t>::max();
   Open();
@@ -1200,7 +1200,7 @@ TEST_F(ColumnFamilyTest, GetComparator) {
   Close();
 }
 
-TEST_F(ColumnFamilyTest, DISABLED_DifferentMergeOperators) {
+TEST_F(ColumnFamilyTest, DifferentMergeOperators) {
   Open();
   CreateColumnFamilies({"first", "second"});
   ColumnFamilyOptions default_cf, first, second;
@@ -1231,7 +1231,7 @@ TEST_F(ColumnFamilyTest, DISABLED_DifferentMergeOperators) {
 }
 
 #ifndef ROCKSDB_LITE  // WaitForFlush() is not supported
-TEST_F(ColumnFamilyTest, DISABLED_DifferentCompactionStyles) {
+TEST_F(ColumnFamilyTest, DifferentCompactionStyles) {
   Open();
   CreateColumnFamilies({"one", "two"});
   ColumnFamilyOptions default_cf, one, two;
@@ -1303,7 +1303,7 @@ TEST_F(ColumnFamilyTest, DISABLED_DifferentCompactionStyles) {
 #ifndef ROCKSDB_LITE
 // Sync points not supported in RocksDB Lite
 
-TEST_F(ColumnFamilyTest, DISABLED_MultipleManualCompactions) {
+TEST_F(ColumnFamilyTest, MultipleManualCompactions) {
   Open();
   CreateColumnFamilies({"one", "two"});
   ColumnFamilyOptions default_cf, one, two;
@@ -1400,7 +1400,7 @@ TEST_F(ColumnFamilyTest, DISABLED_MultipleManualCompactions) {
   Close();
 }
 
-TEST_F(ColumnFamilyTest, DISABLED_AutomaticAndManualCompactions) {
+TEST_F(ColumnFamilyTest, AutomaticAndManualCompactions) {
   Open();
   CreateColumnFamilies({"one", "two"});
   ColumnFamilyOptions default_cf, one, two;
@@ -1493,7 +1493,7 @@ TEST_F(ColumnFamilyTest, DISABLED_AutomaticAndManualCompactions) {
   }
 }
 
-TEST_F(ColumnFamilyTest, DISABLED_ManualAndAutomaticCompactions) {
+TEST_F(ColumnFamilyTest, ManualAndAutomaticCompactions) {
   Open();
   CreateColumnFamilies({"one", "two"});
   ColumnFamilyOptions default_cf, one, two;
@@ -1589,7 +1589,7 @@ TEST_F(ColumnFamilyTest, DISABLED_ManualAndAutomaticCompactions) {
   }
 }
 
-TEST_F(ColumnFamilyTest, DISABLED_SameCFManualManualCompactions) {
+TEST_F(ColumnFamilyTest, SameCFManualManualCompactions) {
   Open();
   CreateColumnFamilies({"one"});
   ColumnFamilyOptions default_cf, one;
@@ -1688,7 +1688,7 @@ TEST_F(ColumnFamilyTest, DISABLED_SameCFManualManualCompactions) {
   }
 }
 
-TEST_F(ColumnFamilyTest, DISABLED_SameCFManualAutomaticCompactions) {
+TEST_F(ColumnFamilyTest, SameCFManualAutomaticCompactions) {
   Open();
   CreateColumnFamilies({"one"});
   ColumnFamilyOptions default_cf, one;
@@ -1778,7 +1778,7 @@ TEST_F(ColumnFamilyTest, DISABLED_SameCFManualAutomaticCompactions) {
   }
 }
 
-TEST_F(ColumnFamilyTest, DISABLED_SameCFManualAutomaticCompactionsLevel) {
+TEST_F(ColumnFamilyTest, SameCFManualAutomaticCompactionsLevel) {
   Open();
   CreateColumnFamilies({"one"});
   ColumnFamilyOptions default_cf, one;
@@ -1875,7 +1875,7 @@ TEST_F(ColumnFamilyTest, DISABLED_SameCFManualAutomaticCompactionsLevel) {
 // This will wait because there is an unscheduled manual compaction.
 // Once the conflict is hit, the manual compaction starts and ends
 // Then another automatic will start and end.
-TEST_F(ColumnFamilyTest, DISABLED_SameCFManualAutomaticConflict) {
+TEST_F(ColumnFamilyTest, SameCFManualAutomaticConflict) {
   Open();
   CreateColumnFamilies({"one"});
   ColumnFamilyOptions default_cf, one;
@@ -1994,7 +1994,7 @@ TEST_F(ColumnFamilyTest, DISABLED_SameCFManualAutomaticConflict) {
 // This will wait because the automatic compaction has files it needs.
 // Once the conflict is hit, the automatic compaction starts and ends
 // Then the manual will run and end.
-TEST_F(ColumnFamilyTest, DISABLED_SameCFAutomaticManualCompactions) {
+TEST_F(ColumnFamilyTest, SameCFAutomaticManualCompactions) {
   Open();
   CreateColumnFamilies({"one"});
   ColumnFamilyOptions default_cf, one;
@@ -2091,7 +2091,7 @@ std::string IterStatus(Iterator* iter) {
 }
 }  // anonymous namespace
 
-TEST_F(ColumnFamilyTest, DISABLED_NewIteratorsTest) {
+TEST_F(ColumnFamilyTest, NewIteratorsTest) {
   // iter == 0 -- no tailing
   // iter == 2 -- tailing
   for (int iter = 0; iter < 2; ++iter) {
@@ -2138,7 +2138,7 @@ TEST_F(ColumnFamilyTest, DISABLED_NewIteratorsTest) {
 #endif  // !ROCKSDB_LITE
 
 #ifndef ROCKSDB_LITE  // ReadOnlyDB is not supported
-TEST_F(ColumnFamilyTest, DISABLED_ReadOnlyDBTest) {
+TEST_F(ColumnFamilyTest, ReadOnlyDBTest) {
   Open();
   CreateColumnFamiliesAndReopen({"one", "two", "three", "four"});
   ASSERT_OK(Put(0, "a", "b"));
@@ -2190,7 +2190,7 @@ TEST_F(ColumnFamilyTest, DISABLED_ReadOnlyDBTest) {
 #endif  // !ROCKSDB_LITE
 
 #ifndef ROCKSDB_LITE  //  WaitForFlush() is not supported in lite
-TEST_F(ColumnFamilyTest, DISABLED_DontRollEmptyLogs) {
+TEST_F(ColumnFamilyTest, DontRollEmptyLogs) {
   Open();
   CreateColumnFamiliesAndReopen({"one", "two", "three", "four"});
 
@@ -2214,7 +2214,7 @@ TEST_F(ColumnFamilyTest, DISABLED_DontRollEmptyLogs) {
 #endif  // !ROCKSDB_LITE
 
 #ifndef ROCKSDB_LITE  //  WaitForCompaction() is not supported in lite
-TEST_F(ColumnFamilyTest, DISABLED_FlushStaleColumnFamilies) {
+TEST_F(ColumnFamilyTest, FlushStaleColumnFamilies) {
   Open();
   CreateColumnFamilies({"one", "two"});
   ColumnFamilyOptions default_cf, one, two;
@@ -2249,7 +2249,7 @@ TEST_F(ColumnFamilyTest, DISABLED_FlushStaleColumnFamilies) {
 }
 #endif  // !ROCKSDB_LITE
 
-TEST_F(ColumnFamilyTest, DISABLED_CreateMissingColumnFamilies) {
+TEST_F(ColumnFamilyTest, CreateMissingColumnFamilies) {
   Status s = TryOpen({"one", "two"});
   ASSERT_TRUE(!s.ok());
   db_options_.create_missing_column_families = true;
@@ -2307,7 +2307,7 @@ TEST_F(ColumnFamilyTest, SanitizeOptions) {
   }
 }
 
-TEST_F(ColumnFamilyTest, DISABLED_ReadDroppedColumnFamily) {
+TEST_F(ColumnFamilyTest, ReadDroppedColumnFamily) {
   // iter 0 -- drop CF, don't reopen
   // iter 1 -- delete CF, reopen
   for (int iter = 0; iter < 2; ++iter) {
@@ -2379,7 +2379,7 @@ TEST_F(ColumnFamilyTest, DISABLED_ReadDroppedColumnFamily) {
   }
 }
 
-TEST_F(ColumnFamilyTest, DISABLED_FlushAndDropRaceCondition) {
+TEST_F(ColumnFamilyTest, FlushAndDropRaceCondition) {
   db_options_.create_missing_column_families = true;
   Open({"default", "one"});
   ColumnFamilyOptions options;
@@ -2911,7 +2911,7 @@ TEST_F(ColumnFamilyTest, CompactionSpeedupTwoColumnFamilies) {
 }
 
 #ifndef ROCKSDB_LITE
-TEST_F(ColumnFamilyTest, DISABLED_FlushCloseWALFiles) {
+TEST_F(ColumnFamilyTest, FlushCloseWALFiles) {
   SpecialEnv env(Env::Default());
   db_options_.env = &env;
   db_options_.max_background_flushes = 1;
@@ -2953,7 +2953,7 @@ TEST_F(ColumnFamilyTest, DISABLED_FlushCloseWALFiles) {
 #endif  // !ROCKSDB_LITE
 
 #ifndef ROCKSDB_LITE  // WaitForFlush() is not supported
-TEST_F(ColumnFamilyTest, DISABLED_IteratorCloseWALFile1) {
+TEST_F(ColumnFamilyTest, IteratorCloseWALFile1) {
   SpecialEnv env(Env::Default());
   db_options_.env = &env;
   db_options_.max_background_flushes = 1;
@@ -2998,7 +2998,7 @@ TEST_F(ColumnFamilyTest, DISABLED_IteratorCloseWALFile1) {
   Close();
 }
 
-TEST_F(ColumnFamilyTest, DISABLED_IteratorCloseWALFile2) {
+TEST_F(ColumnFamilyTest, IteratorCloseWALFile2) {
   SpecialEnv env(Env::Default());
   // Allow both of flush and purge job to schedule.
   env.SetBackgroundThreads(2, Env::HIGH);
@@ -3055,7 +3055,7 @@ TEST_F(ColumnFamilyTest, DISABLED_IteratorCloseWALFile2) {
 #endif  // !ROCKSDB_LITE
 
 #ifndef ROCKSDB_LITE  // TEST functions are not supported in lite
-TEST_F(ColumnFamilyTest, DISABLED_ForwardIteratorCloseWALFile) {
+TEST_F(ColumnFamilyTest, ForwardIteratorCloseWALFile) {
   SpecialEnv env(Env::Default());
   // Allow both of flush and purge job to schedule.
   env.SetBackgroundThreads(2, Env::HIGH);
@@ -3132,7 +3132,7 @@ TEST_F(ColumnFamilyTest, DISABLED_ForwardIteratorCloseWALFile) {
 // Disable on windows because SyncWAL requires env->IsSyncThreadSafe()
 // to return true which is not so in unbuffered mode.
 #ifndef OS_WIN
-TEST_F(ColumnFamilyTest, DISABLED_LogSyncConflictFlush) {
+TEST_F(ColumnFamilyTest, LogSyncConflictFlush) {
   Open();
   CreateColumnFamiliesAndReopen({"one", "two"});
 

--- a/db/compaction_job_stats_test.cc
+++ b/db/compaction_job_stats_test.cc
@@ -140,9 +140,7 @@ class CompactionJobStatsTest : public testing::Test,
     size_t cfi = handles_.size();
     handles_.resize(cfi + cfs.size());
     for (auto cf : cfs) {
-      if (cf != "default") {
-        ASSERT_OK(db_->CreateColumnFamily(cf_opts, cf, &handles_[cfi++]));
-      }
+      ASSERT_OK(db_->CreateColumnFamily(cf_opts, cf, &handles_[cfi++]));
     }
   }
 
@@ -666,7 +664,7 @@ TEST_P(CompactionJobStatsTest, CompactionJobStatsTest) {
   options.report_bg_io_stats = true;
   for (int test = 0; test < 2; ++test) {
     DestroyAndReopen(options);
-    CreateAndReopenWithCF({"default"}, options);
+    CreateAndReopenWithCF({"pikachu"}, options);
 
     // 1st Phase: generate "num_L0_files" L0 files.
     int num_L0_files = 0;
@@ -884,7 +882,7 @@ TEST_P(CompactionJobStatsTest, DeletionStatsTest) {
   options.max_subcompactions = max_subcompactions_;
 
   DestroyAndReopen(options);
-  CreateAndReopenWithCF({"default"}, options);
+  CreateAndReopenWithCF({"pikachu"}, options);
 
   // Stage 1: Generate several L0 files and then send them to L2 by
   // using CompactRangeOptions and CompactRange(). These files will
@@ -976,7 +974,7 @@ TEST_P(CompactionJobStatsTest, UniversalCompactionTest) {
   options.max_subcompactions = max_subcompactions_;
 
   DestroyAndReopen(options);
-  CreateAndReopenWithCF({"default"}, options);
+  CreateAndReopenWithCF({"pikachu"}, options);
 
   // Generates the expected CompactionJobStats for each compaction
   for (uint32_t num_flushes = 2; num_flushes <= kTestScale; num_flushes++) {

--- a/db/compaction_job_test.cc
+++ b/db/compaction_job_test.cc
@@ -195,7 +195,6 @@ class CompactionJobTest : public testing::Test {
     new_db.SetLogNumber(0);
     new_db.SetNextFile(2);
     new_db.SetLastSequence(0);
-    new_db.SetValueSchemaVersion(0);
 
     const std::string manifest = DescriptorFileName(dbname_, 1);
     unique_ptr<WritableFile> file;

--- a/db/corruption_test.cc
+++ b/db/corruption_test.cc
@@ -105,9 +105,7 @@ class CorruptionTest : public testing::Test {
       Slice key = Key(i, &key_space);
       batch.Clear();
       batch.Put(key, Value(i, &value_space));
-      WriteOptions wop;
-      wop.disableWAL = true;
-      ASSERT_OK(db_->Write(wop, &batch));
+      ASSERT_OK(db_->Write(WriteOptions(), &batch));
     }
   }
 
@@ -257,7 +255,7 @@ class CorruptionTest : public testing::Test {
   }
 };
 
-TEST_F(CorruptionTest, DISABLED_Recovery) {             // PEGASUS: pegasus does not use wal, ignore this case
+TEST_F(CorruptionTest, Recovery) {
   Build(100);
   Check(100, 100);
 #ifdef OS_WIN
@@ -341,14 +339,14 @@ TEST_F(CorruptionTest, TableFileIndexData) {
   ASSERT_NOK(dbi->VerifyChecksum());
 }
 
-TEST_F(CorruptionTest, DISABLED_MissingDescriptor) {    // PEGASUS: last_flush_sequence is lost when repair
+TEST_F(CorruptionTest, MissingDescriptor) {
   Build(1000);
   RepairDB();
   Reopen();
   Check(1000, 1000);
 }
 
-TEST_F(CorruptionTest, DISABLED_SequenceNumberRecovery) {     // PEGASUS: last_flush_sequence is lost when repair
+TEST_F(CorruptionTest, SequenceNumberRecovery) {
   ASSERT_OK(db_->Put(WriteOptions(), "foo", "v1"));
   ASSERT_OK(db_->Put(WriteOptions(), "foo", "v2"));
   ASSERT_OK(db_->Put(WriteOptions(), "foo", "v3"));
@@ -369,7 +367,7 @@ TEST_F(CorruptionTest, DISABLED_SequenceNumberRecovery) {     // PEGASUS: last_f
   ASSERT_EQ("v6", v);
 }
 
-TEST_F(CorruptionTest, DISABLED_CorruptedDescriptor) {        // PEGASUS: last_flush_sequence is lost when repair
+TEST_F(CorruptionTest, CorruptedDescriptor) {
   ASSERT_OK(db_->Put(WriteOptions(), "foo", "hello"));
   DBImpl* dbi = reinterpret_cast<DBImpl*>(db_);
   dbi->TEST_FlushMemTable();

--- a/db/db_basic_test.cc
+++ b/db/db_basic_test.cc
@@ -169,11 +169,12 @@ TEST_F(DBBasicTest, CompactedDB) {
 
 TEST_F(DBBasicTest, LevelLimitReopen) {
   Options options = CurrentOptions();
+  CreateAndReopenWithCF({"pikachu"}, options);
 
   const std::string value(1024 * 1024, ' ');
   int i = 0;
-  while (NumTableFilesAtLevel(2, 0) == 0) {
-    ASSERT_OK(Put(Key(i++), value));
+  while (NumTableFilesAtLevel(2, 1) == 0) {
+    ASSERT_OK(Put(1, Key(i++), value));
     dbfull()->TEST_WaitForFlushMemTable();
     dbfull()->TEST_WaitForCompact();
   }
@@ -187,36 +188,36 @@ TEST_F(DBBasicTest, LevelLimitReopen) {
 
   options.num_levels = 10;
   options.max_bytes_for_level_multiplier_additional.resize(10, 1);
-  ASSERT_OK(TryReopenWithColumnFamilies({"default"}, options));
+  ASSERT_OK(TryReopenWithColumnFamilies({"default", "pikachu"}, options));
 }
 #endif  // ROCKSDB_LITE
 
 TEST_F(DBBasicTest, PutDeleteGet) {
   do {
-    ASSERT_OK(Put("foo", "v1"));
-    ASSERT_EQ("v1", Get("foo"));
-    ASSERT_OK(Put("foo", "v2"));
-    ASSERT_EQ("v2", Get("foo"));
-    ASSERT_OK(Delete("foo"));
-    ASSERT_EQ("NOT_FOUND", Get("foo"));
-  } while (ChangeOptions(kSkipPipelinedWrite));
+    CreateAndReopenWithCF({"pikachu"}, CurrentOptions());
+    ASSERT_OK(Put(1, "foo", "v1"));
+    ASSERT_EQ("v1", Get(1, "foo"));
+    ASSERT_OK(Put(1, "foo", "v2"));
+    ASSERT_EQ("v2", Get(1, "foo"));
+    ASSERT_OK(Delete(1, "foo"));
+    ASSERT_EQ("NOT_FOUND", Get(1, "foo"));
+  } while (ChangeOptions());
 }
 
 TEST_F(DBBasicTest, PutSingleDeleteGet) {
   do {
-    //CreateAndReopenWithCF({"pikachu"}, CurrentOptions());
-    ASSERT_OK(Put("foo", "v1"));
-    ASSERT_EQ("v1", Get("foo"));
-    ASSERT_OK(Put("foo2", "v2"));
-    ASSERT_EQ("v2", Get("foo2"));
-    ASSERT_OK(SingleDelete("foo"));
-    ASSERT_EQ("NOT_FOUND", Get("foo"));
+    CreateAndReopenWithCF({"pikachu"}, CurrentOptions());
+    ASSERT_OK(Put(1, "foo", "v1"));
+    ASSERT_EQ("v1", Get(1, "foo"));
+    ASSERT_OK(Put(1, "foo2", "v2"));
+    ASSERT_EQ("v2", Get(1, "foo2"));
+    ASSERT_OK(SingleDelete(1, "foo"));
+    ASSERT_EQ("NOT_FOUND", Get(1, "foo"));
     // Skip HashCuckooRep as it does not support single delete. FIFO and
     // universal compaction do not apply to the test case. Skip MergePut
     // because single delete does not get removed when it encounters a merge.
   } while (ChangeOptions(kSkipHashCuckoo | kSkipFIFOCompaction |
-                         kSkipUniversalCompaction | kSkipMergePut |
-                         kSkipPipelinedWrite));
+                         kSkipUniversalCompaction | kSkipMergePut));
 }
 
 TEST_F(DBBasicTest, EmptyFlush) {
@@ -227,27 +228,28 @@ TEST_F(DBBasicTest, EmptyFlush) {
 
     Options options = CurrentOptions();
     options.disable_auto_compactions = true;
+    CreateAndReopenWithCF({"pikachu"}, options);
 
-    Put("a", Slice());
-    SingleDelete("a");
-    ASSERT_OK(Flush(0));
+    Put(1, "a", Slice());
+    SingleDelete(1, "a");
+    ASSERT_OK(Flush(1));
 
-    ASSERT_EQ("[ ]", AllEntriesFor("a", 0));
+    ASSERT_EQ("[ ]", AllEntriesFor("a", 1));
     // Skip HashCuckooRep as it does not support single delete. FIFO and
     // universal compaction do not apply to the test case. Skip MergePut
     // because merges cannot be combined with single deletions.
   } while (ChangeOptions(kSkipHashCuckoo | kSkipFIFOCompaction |
-                         kSkipUniversalCompaction | kSkipMergePut| kSkipPipelinedWrite));
+                         kSkipUniversalCompaction | kSkipMergePut));
 }
 
 TEST_F(DBBasicTest, GetFromVersions) {
   do {
-    //CreateAndReopenWithCF({"pikachu"}, CurrentOptions());
-    ASSERT_OK(Put("foo", "v1"));
-    ASSERT_OK(Flush(0));
-    ASSERT_EQ("v1", Get("foo"));
-//    ASSERT_EQ("NOT_FOUND", Get(0, "foo"));
-  } while (ChangeOptions(kSkipPipelinedWrite));
+    CreateAndReopenWithCF({"pikachu"}, CurrentOptions());
+    ASSERT_OK(Put(1, "foo", "v1"));
+    ASSERT_OK(Flush(1));
+    ASSERT_EQ("v1", Get(1, "foo"));
+    ASSERT_EQ("NOT_FOUND", Get(0, "foo"));
+  } while (ChangeOptions());
 }
 
 #ifndef ROCKSDB_LITE
@@ -255,26 +257,26 @@ TEST_F(DBBasicTest, GetSnapshot) {
   anon::OptionsOverride options_override;
   options_override.skip_policy = kSkipNoSnapshot;
   do {
-//    CreateAndReopenWithCF({"pikachu"}, CurrentOptions(options_override));
+    CreateAndReopenWithCF({"pikachu"}, CurrentOptions(options_override));
     // Try with both a short key and a long key
     for (int i = 0; i < 2; i++) {
       std::string key = (i == 0) ? std::string("foo") : std::string(200, 'x');
-      ASSERT_OK(Put(key, "v1"));
+      ASSERT_OK(Put(1, key, "v1"));
       const Snapshot* s1 = db_->GetSnapshot();
       if (option_config_ == kHashCuckoo) {
         // Unsupported case.
         ASSERT_TRUE(s1 == nullptr);
         break;
       }
-      ASSERT_OK(Put(key, "v2"));
-      ASSERT_EQ("v2", Get(key));
-      ASSERT_EQ("v1", Get(key, s1));
-      ASSERT_OK(Flush(0));
-      ASSERT_EQ("v2", Get(key));
-      ASSERT_EQ("v1", Get(key, s1));
+      ASSERT_OK(Put(1, key, "v2"));
+      ASSERT_EQ("v2", Get(1, key));
+      ASSERT_EQ("v1", Get(1, key, s1));
+      ASSERT_OK(Flush(1));
+      ASSERT_EQ("v2", Get(1, key));
+      ASSERT_EQ("v1", Get(1, key, s1));
       db_->ReleaseSnapshot(s1);
     }
-  } while (ChangeOptions(kSkipPipelinedWrite));
+  } while (ChangeOptions());
 }
 #endif  // ROCKSDB_LITE
 
@@ -297,18 +299,18 @@ TEST_F(DBBasicTest, FlushMultipleMemtable) {
     options.max_write_buffer_number = 4;
     options.min_write_buffer_number_to_merge = 3;
     options.max_write_buffer_number_to_maintain = -1;
-    //CreateAndReopenWithCF({"pikachu"}, options);
-    ASSERT_OK(dbfull()->Put(writeOpt,"foo", "v1"));
-    ASSERT_OK(Flush(0));
-    ASSERT_OK(dbfull()->Put(writeOpt,"bar", "v1"));
+    CreateAndReopenWithCF({"pikachu"}, options);
+    ASSERT_OK(dbfull()->Put(writeOpt, handles_[1], "foo", "v1"));
+    ASSERT_OK(Flush(1));
+    ASSERT_OK(dbfull()->Put(writeOpt, handles_[1], "bar", "v1"));
 
-    ASSERT_EQ("v1", Get("foo"));
-    ASSERT_EQ("v1", Get("bar"));
-    ASSERT_OK(Flush(0));
+    ASSERT_EQ("v1", Get(1, "foo"));
+    ASSERT_EQ("v1", Get(1, "bar"));
+    ASSERT_OK(Flush(1));
   } while (ChangeCompactOptions());
 }
 
-TEST_F(DBBasicTest, DISABLED_FlushEmptyColumnFamily) {
+TEST_F(DBBasicTest, FlushEmptyColumnFamily) {
   // Block flush thread and disable compaction thread
   env_->SetBackgroundThreads(1, Env::HIGH);
   env_->SetBackgroundThreads(1, Env::LOW);
@@ -329,15 +331,10 @@ TEST_F(DBBasicTest, DISABLED_FlushEmptyColumnFamily) {
   options.max_write_buffer_number_to_maintain = 1;
   CreateAndReopenWithCF({"pikachu"}, options);
 
-  auto cfh = dbfull()->DefaultColumnFamily();
-  auto cfd = reinterpret_cast<ColumnFamilyHandleImpl*>(cfh)->cfd();
-  ASSERT_EQ(0, cfd->imm()->NumNotFlushed());
-
   // Compaction can still go through even if no thread can flush the
   // mem table.
   ASSERT_OK(Flush(0));
   ASSERT_OK(Flush(1));
-  ASSERT_EQ(0, cfd->imm()->NumNotFlushed());
 
   // Insert can go through
   ASSERT_OK(dbfull()->Put(writeOpt, handles_[0], "foo", "v1"));
@@ -346,34 +343,12 @@ TEST_F(DBBasicTest, DISABLED_FlushEmptyColumnFamily) {
   ASSERT_EQ("v1", Get(0, "foo"));
   ASSERT_EQ("v1", Get(1, "bar"));
 
-  // Compaction without waiting will go through even if no thread can
-  // flush the mem table, which will switch the mem table.
-  FlushOptions flush_options;
-  flush_options.wait = false;
-  ASSERT_OK(Flush(0, flush_options));
-  ASSERT_OK(Flush(1, flush_options));
-  ASSERT_EQ(1, cfd->imm()->NumNotFlushed());
-
-  // Compaction without waiting will go through even if no thread can
-  // flush the mem table, and no new compaction will be started.
-  ASSERT_OK(Flush(0, flush_options));
-  ASSERT_OK(Flush(1, flush_options));
-  ASSERT_EQ(1, cfd->imm()->NumNotFlushed());
-
-  // Insert can go through
-  ASSERT_OK(dbfull()->Put(writeOpt, handles_[0], "k1", "v1"));
-  ASSERT_OK(dbfull()->Put(writeOpt, handles_[1], "k2", "v2"));
-
-  ASSERT_EQ("v1", Get(0, "k1"));
-  ASSERT_EQ("v2", Get(1, "k2"));
-
   sleeping_task_high.WakeUp();
   sleeping_task_high.WaitUntilDone();
 
   // Flush can still go through.
   ASSERT_OK(Flush(0));
   ASSERT_OK(Flush(1));
-  ASSERT_EQ(0, cfd->imm()->NumNotFlushed());
 
   sleeping_task_low.WakeUp();
   sleeping_task_low.WaitUntilDone();
@@ -381,45 +356,45 @@ TEST_F(DBBasicTest, DISABLED_FlushEmptyColumnFamily) {
 
 TEST_F(DBBasicTest, FLUSH) {
   do {
-//    CreateAndReopenWithCF({"pikachu"}, CurrentOptions());
+    CreateAndReopenWithCF({"pikachu"}, CurrentOptions());
     WriteOptions writeOpt = WriteOptions();
     writeOpt.disableWAL = true;
     SetPerfLevel(kEnableTime);
-    ASSERT_OK(dbfull()->Put(writeOpt,"foo", "v1"));
+    ASSERT_OK(dbfull()->Put(writeOpt, handles_[1], "foo", "v1"));
     // this will now also flush the last 2 writes
-    ASSERT_OK(Flush(0));
-    ASSERT_OK(dbfull()->Put(writeOpt,"bar", "v1"));
+    ASSERT_OK(Flush(1));
+    ASSERT_OK(dbfull()->Put(writeOpt, handles_[1], "bar", "v1"));
 
     get_perf_context()->Reset();
-    Get("foo");
+    Get(1, "foo");
     ASSERT_TRUE((int)get_perf_context()->get_from_output_files_time > 0);
     ASSERT_EQ(2, (int)get_perf_context()->get_read_bytes);
 
-    ReopenWithColumnFamilies({"default"}, CurrentOptions());
-    ASSERT_EQ("v1", Get("foo"));
-    ASSERT_EQ("v1", Get("bar"));
+    ReopenWithColumnFamilies({"default", "pikachu"}, CurrentOptions());
+    ASSERT_EQ("v1", Get(1, "foo"));
+    ASSERT_EQ("v1", Get(1, "bar"));
 
     writeOpt.disableWAL = true;
-    ASSERT_OK(dbfull()->Put(writeOpt, "bar", "v2"));
-    ASSERT_OK(dbfull()->Put(writeOpt, "foo", "v2"));
-    ASSERT_OK(Flush(0));
+    ASSERT_OK(dbfull()->Put(writeOpt, handles_[1], "bar", "v2"));
+    ASSERT_OK(dbfull()->Put(writeOpt, handles_[1], "foo", "v2"));
+    ASSERT_OK(Flush(1));
 
-    ReopenWithColumnFamilies({"default"}, CurrentOptions());
-    ASSERT_EQ("v2", Get("bar"));
+    ReopenWithColumnFamilies({"default", "pikachu"}, CurrentOptions());
+    ASSERT_EQ("v2", Get(1, "bar"));
     get_perf_context()->Reset();
-    ASSERT_EQ("v2", Get("foo"));
+    ASSERT_EQ("v2", Get(1, "foo"));
     ASSERT_TRUE((int)get_perf_context()->get_from_output_files_time > 0);
 
     writeOpt.disableWAL = false;
-    ASSERT_OK(dbfull()->Put(writeOpt, "bar", "v3"));
-    ASSERT_OK(dbfull()->Put(writeOpt, "foo", "v3"));
-    ASSERT_OK(Flush(0));
+    ASSERT_OK(dbfull()->Put(writeOpt, handles_[1], "bar", "v3"));
+    ASSERT_OK(dbfull()->Put(writeOpt, handles_[1], "foo", "v3"));
+    ASSERT_OK(Flush(1));
 
-    ReopenWithColumnFamilies({"default"}, CurrentOptions());
+    ReopenWithColumnFamilies({"default", "pikachu"}, CurrentOptions());
     // 'foo' should be there because its put
     // has WAL enabled.
-    ASSERT_EQ("v3", Get("foo"));
-    ASSERT_EQ("v3", Get("bar"));
+    ASSERT_EQ("v3", Get(1, "foo"));
+    ASSERT_EQ("v3", Get(1, "bar"));
 
     SetPerfLevel(kDisable);
   } while (ChangeCompactOptions());
@@ -430,20 +405,21 @@ TEST_F(DBBasicTest, ManifestRollOver) {
     Options options;
     options.max_manifest_file_size = 10;  // 10 bytes
     options = CurrentOptions(options);
+    CreateAndReopenWithCF({"pikachu"}, options);
     {
-      ASSERT_OK(Put("manifest_key1", std::string(1000, '1')));
-      ASSERT_OK(Put("manifest_key2", std::string(1000, '2')));
-      ASSERT_OK(Put("manifest_key3", std::string(1000, '3')));
+      ASSERT_OK(Put(1, "manifest_key1", std::string(1000, '1')));
+      ASSERT_OK(Put(1, "manifest_key2", std::string(1000, '2')));
+      ASSERT_OK(Put(1, "manifest_key3", std::string(1000, '3')));
       uint64_t manifest_before_flush = dbfull()->TEST_Current_Manifest_FileNo();
-      ASSERT_OK(Flush(0));  // This should trigger LogAndApply.
+      ASSERT_OK(Flush(1));  // This should trigger LogAndApply.
       uint64_t manifest_after_flush = dbfull()->TEST_Current_Manifest_FileNo();
       ASSERT_GT(manifest_after_flush, manifest_before_flush);
-      ReopenWithColumnFamilies({"default"}, options);
+      ReopenWithColumnFamilies({"default", "pikachu"}, options);
       ASSERT_GT(dbfull()->TEST_Current_Manifest_FileNo(), manifest_after_flush);
       // check if a new manifest file got inserted or not.
-      ASSERT_EQ(std::string(1000, '1'), Get("manifest_key1"));
-      ASSERT_EQ(std::string(1000, '2'), Get("manifest_key2"));
-      ASSERT_EQ(std::string(1000, '3'), Get("manifest_key3"));
+      ASSERT_EQ(std::string(1000, '1'), Get(1, "manifest_key1"));
+      ASSERT_EQ(std::string(1000, '2'), Get(1, "manifest_key2"));
+      ASSERT_EQ(std::string(1000, '3'), Get(1, "manifest_key3"));
     }
   } while (ChangeCompactOptions());
 }
@@ -475,64 +451,64 @@ TEST_F(DBBasicTest, Snapshot) {
   anon::OptionsOverride options_override;
   options_override.skip_policy = kSkipNoSnapshot;
   do {
-    //CreateAndReopenWithCF({"pikachu"}, CurrentOptions(options_override));
-    Put(/*0, */"foo", "0v1");
-    //Put(1, "foo", "1v1");
+    CreateAndReopenWithCF({"pikachu"}, CurrentOptions(options_override));
+    Put(0, "foo", "0v1");
+    Put(1, "foo", "1v1");
 
     const Snapshot* s1 = db_->GetSnapshot();
     ASSERT_EQ(1U, GetNumSnapshots());
     uint64_t time_snap1 = GetTimeOldestSnapshots();
     ASSERT_GT(time_snap1, 0U);
-    Put(/*0, */"foo", "0v2");
-    //Put(1, "foo", "1v2");
+    Put(0, "foo", "0v2");
+    Put(1, "foo", "1v2");
 
     env_->addon_time_.fetch_add(1);
 
     const Snapshot* s2 = db_->GetSnapshot();
     ASSERT_EQ(2U, GetNumSnapshots());
     ASSERT_EQ(time_snap1, GetTimeOldestSnapshots());
-    Put(/*0, */"foo", "0v3");
-    //Put(1, "foo", "1v3");
+    Put(0, "foo", "0v3");
+    Put(1, "foo", "1v3");
 
     {
       ManagedSnapshot s3(db_);
       ASSERT_EQ(3U, GetNumSnapshots());
       ASSERT_EQ(time_snap1, GetTimeOldestSnapshots());
 
-      Put(/*0, */"foo", "0v4");
-      //Put(1, "foo", "1v4");
-      ASSERT_EQ("0v1", Get(/*0, */"foo", s1));
-      //ASSERT_EQ("1v1", Get(1, "foo", s1));
-      ASSERT_EQ("0v2", Get(/*0, */"foo", s2));
-      //ASSERT_EQ("1v2", Get(1, "foo", s2));
-      ASSERT_EQ("0v3", Get(/*0, */"foo", s3.snapshot()));
-      //ASSERT_EQ("1v3", Get(1, "foo", s3.snapshot()));
-      ASSERT_EQ("0v4", Get(/*0, */"foo"));
-      //ASSERT_EQ("1v4", Get(1, "foo"));
+      Put(0, "foo", "0v4");
+      Put(1, "foo", "1v4");
+      ASSERT_EQ("0v1", Get(0, "foo", s1));
+      ASSERT_EQ("1v1", Get(1, "foo", s1));
+      ASSERT_EQ("0v2", Get(0, "foo", s2));
+      ASSERT_EQ("1v2", Get(1, "foo", s2));
+      ASSERT_EQ("0v3", Get(0, "foo", s3.snapshot()));
+      ASSERT_EQ("1v3", Get(1, "foo", s3.snapshot()));
+      ASSERT_EQ("0v4", Get(0, "foo"));
+      ASSERT_EQ("1v4", Get(1, "foo"));
     }
 
     ASSERT_EQ(2U, GetNumSnapshots());
     ASSERT_EQ(time_snap1, GetTimeOldestSnapshots());
-    ASSERT_EQ("0v1", Get(/*0, */"foo", s1));
-    //ASSERT_EQ("1v1", Get(1, "foo", s1));
-    ASSERT_EQ("0v2", Get(/*0, */"foo", s2));
-    //ASSERT_EQ("1v2", Get(1, "foo", s2));
-    ASSERT_EQ("0v4", Get(/*0, */"foo"));
-    //ASSERT_EQ("1v4", Get(1, "foo"));
+    ASSERT_EQ("0v1", Get(0, "foo", s1));
+    ASSERT_EQ("1v1", Get(1, "foo", s1));
+    ASSERT_EQ("0v2", Get(0, "foo", s2));
+    ASSERT_EQ("1v2", Get(1, "foo", s2));
+    ASSERT_EQ("0v4", Get(0, "foo"));
+    ASSERT_EQ("1v4", Get(1, "foo"));
 
     db_->ReleaseSnapshot(s1);
-    ASSERT_EQ("0v2", Get(/*0, */"foo", s2));
-    //ASSERT_EQ("1v2", Get(1, "foo", s2));
-    ASSERT_EQ("0v4", Get(/*0, */"foo"));
-    //ASSERT_EQ("1v4", Get(1, "foo"));
+    ASSERT_EQ("0v2", Get(0, "foo", s2));
+    ASSERT_EQ("1v2", Get(1, "foo", s2));
+    ASSERT_EQ("0v4", Get(0, "foo"));
+    ASSERT_EQ("1v4", Get(1, "foo"));
     ASSERT_EQ(1U, GetNumSnapshots());
     ASSERT_LT(time_snap1, GetTimeOldestSnapshots());
 
     db_->ReleaseSnapshot(s2);
     ASSERT_EQ(0U, GetNumSnapshots());
-    ASSERT_EQ("0v4", Get(/*0, */"foo"));
-    //ASSERT_EQ("1v4", Get(1, "foo"));
-  } while (ChangeOptions(kSkipHashCuckoo | kSkipPipelinedWrite));
+    ASSERT_EQ("0v4", Get(0, "foo"));
+    ASSERT_EQ("1v4", Get(1, "foo"));
+  } while (ChangeOptions(kSkipHashCuckoo));
 }
 
 #endif  // ROCKSDB_LITE
@@ -543,54 +519,53 @@ TEST_F(DBBasicTest, CompactBetweenSnapshots) {
   do {
     Options options = CurrentOptions(options_override);
     options.disable_auto_compactions = true;
-    Reopen(options);
+    CreateAndReopenWithCF({"pikachu"}, options);
     Random rnd(301);
-    FillLevels("a", "z", 0);
+    FillLevels("a", "z", 1);
 
-    Put("foo", "first");
+    Put(1, "foo", "first");
     const Snapshot* snapshot1 = db_->GetSnapshot();
-    Put("foo", "second");
-    Put("foo", "third");
-    Put("foo", "fourth");
+    Put(1, "foo", "second");
+    Put(1, "foo", "third");
+    Put(1, "foo", "fourth");
     const Snapshot* snapshot2 = db_->GetSnapshot();
-    Put("foo", "fifth");
-    Put("foo", "sixth");
+    Put(1, "foo", "fifth");
+    Put(1, "foo", "sixth");
 
     // All entries (including duplicates) exist
     // before any compaction or flush is triggered.
-    ASSERT_EQ(AllEntriesFor("foo", 0),
+    ASSERT_EQ(AllEntriesFor("foo", 1),
               "[ sixth, fifth, fourth, third, second, first ]");
-    ASSERT_EQ("sixth", Get("foo"));
-    ASSERT_EQ("fourth", Get("foo", snapshot2));
-    ASSERT_EQ("first", Get("foo", snapshot1));
+    ASSERT_EQ("sixth", Get(1, "foo"));
+    ASSERT_EQ("fourth", Get(1, "foo", snapshot2));
+    ASSERT_EQ("first", Get(1, "foo", snapshot1));
 
     // After a flush, "second", "third" and "fifth" should
     // be removed
-    ASSERT_OK(Flush(0));
-    ASSERT_EQ(AllEntriesFor("foo"), "[ sixth, fourth, first ]");
+    ASSERT_OK(Flush(1));
+    ASSERT_EQ(AllEntriesFor("foo", 1), "[ sixth, fourth, first ]");
 
     // after we release the snapshot1, only two values left
     db_->ReleaseSnapshot(snapshot1);
-    FillLevels("a", "z", 0);
-    dbfull()->CompactRange(CompactRangeOptions(), nullptr,
+    FillLevels("a", "z", 1);
+    dbfull()->CompactRange(CompactRangeOptions(), handles_[1], nullptr,
                            nullptr);
 
     // We have only one valid snapshot snapshot2. Since snapshot1 is
     // not valid anymore, "first" should be removed by a compaction.
-    ASSERT_EQ("sixth", Get("foo"));
-    ASSERT_EQ("fourth", Get("foo", snapshot2));
-    ASSERT_EQ(AllEntriesFor("foo", 0), "[ sixth, fourth ]");
+    ASSERT_EQ("sixth", Get(1, "foo"));
+    ASSERT_EQ("fourth", Get(1, "foo", snapshot2));
+    ASSERT_EQ(AllEntriesFor("foo", 1), "[ sixth, fourth ]");
 
     // after we release the snapshot2, only one value should be left
     db_->ReleaseSnapshot(snapshot2);
-    FillLevels("a", "z", 0);
-    dbfull()->CompactRange(CompactRangeOptions(), nullptr,
+    FillLevels("a", "z", 1);
+    dbfull()->CompactRange(CompactRangeOptions(), handles_[1], nullptr,
                            nullptr);
-    ASSERT_EQ("sixth", Get("foo"));
-    ASSERT_EQ(AllEntriesFor("foo", 0), "[ sixth ]");
+    ASSERT_EQ("sixth", Get(1, "foo"));
+    ASSERT_EQ(AllEntriesFor("foo", 1), "[ sixth ]");
     // skip HashCuckooRep as it does not support snapshot
-  } while (ChangeOptions(kSkipHashCuckoo | kSkipFIFOCompaction
-                         | kSkipPipelinedWrite));
+  } while (ChangeOptions(kSkipHashCuckoo | kSkipFIFOCompaction));
 }
 
 TEST_F(DBBasicTest, DBOpen_Options) {
@@ -638,98 +613,94 @@ TEST_F(DBBasicTest, CompactOnFlush) {
   do {
     Options options = CurrentOptions(options_override);
     options.disable_auto_compactions = true;
-    //CreateAndReopenWithCF({"pikachu"}, options);
+    CreateAndReopenWithCF({"pikachu"}, options);
 
-    Put("foo", "v1");
-    ASSERT_OK(Flush(0));
-    ASSERT_EQ(AllEntriesFor("foo", 0), "[ v1 ]");
+    Put(1, "foo", "v1");
+    ASSERT_OK(Flush(1));
+    ASSERT_EQ(AllEntriesFor("foo", 1), "[ v1 ]");
 
     // Write two new keys
-    Put("a", "begin");
-    Put("z", "end");
-    Flush(0);
+    Put(1, "a", "begin");
+    Put(1, "z", "end");
+    Flush(1);
 
     // Case1: Delete followed by a put
-    Delete("foo");
-    Put("foo", "v2");
-    ASSERT_EQ(AllEntriesFor("foo", 0), "[ v2, DEL, v1 ]");
+    Delete(1, "foo");
+    Put(1, "foo", "v2");
+    ASSERT_EQ(AllEntriesFor("foo", 1), "[ v2, DEL, v1 ]");
 
     // After the current memtable is flushed, the DEL should
     // have been removed
-    ASSERT_OK(Flush(0));
-    ASSERT_EQ(AllEntriesFor("foo", 0), "[ v2, v1 ]");
+    ASSERT_OK(Flush(1));
+    ASSERT_EQ(AllEntriesFor("foo", 1), "[ v2, v1 ]");
 
-    Put("foo", "v2");        // add data to memtable to ensure compact will be executed
-    dbfull()->CompactRange(CompactRangeOptions(), nullptr,
+    dbfull()->CompactRange(CompactRangeOptions(), handles_[1], nullptr,
                            nullptr);
-    ASSERT_EQ(AllEntriesFor("foo", 0), "[ v2 ]");
+    ASSERT_EQ(AllEntriesFor("foo", 1), "[ v2 ]");
 
     // Case 2: Delete followed by another delete
-    Delete("foo");
-    Delete("foo");
-    ASSERT_EQ(AllEntriesFor("foo"), "[ DEL, DEL, v2 ]");
-    ASSERT_OK(Flush(0));
-    ASSERT_EQ(AllEntriesFor("foo", 0), "[ DEL, v2 ]");
-    Delete("foo");
-    dbfull()->CompactRange(CompactRangeOptions(), nullptr,
+    Delete(1, "foo");
+    Delete(1, "foo");
+    ASSERT_EQ(AllEntriesFor("foo", 1), "[ DEL, DEL, v2 ]");
+    ASSERT_OK(Flush(1));
+    ASSERT_EQ(AllEntriesFor("foo", 1), "[ DEL, v2 ]");
+    dbfull()->CompactRange(CompactRangeOptions(), handles_[1], nullptr,
                            nullptr);
-    ASSERT_EQ(AllEntriesFor("foo", 0), "[ ]");
+    ASSERT_EQ(AllEntriesFor("foo", 1), "[ ]");
 
     // Case 3: Put followed by a delete
-    Put("foo", "v3");
-    Delete("foo");
-    ASSERT_EQ(AllEntriesFor("foo", 0), "[ DEL, v3 ]");
-    ASSERT_OK(Flush(0));
-    ASSERT_EQ(AllEntriesFor("foo", 0), "[ DEL ]");
-    Delete("foo");
-    dbfull()->CompactRange(CompactRangeOptions(), nullptr,
+    Put(1, "foo", "v3");
+    Delete(1, "foo");
+    ASSERT_EQ(AllEntriesFor("foo", 1), "[ DEL, v3 ]");
+    ASSERT_OK(Flush(1));
+    ASSERT_EQ(AllEntriesFor("foo", 1), "[ DEL ]");
+    dbfull()->CompactRange(CompactRangeOptions(), handles_[1], nullptr,
                            nullptr);
-    ASSERT_EQ(AllEntriesFor("foo", 0), "[ ]");
+    ASSERT_EQ(AllEntriesFor("foo", 1), "[ ]");
 
     // Case 4: Put followed by another Put
-    Put("foo", "v4");
-    Put("foo", "v5");
-    ASSERT_EQ(AllEntriesFor("foo", 0), "[ v5, v4 ]");
-    ASSERT_OK(Flush(0));
-    ASSERT_EQ(AllEntriesFor("foo", 0), "[ v5 ]");
-    Put("foo", "v5");
-    dbfull()->CompactRange(CompactRangeOptions(), nullptr,
+    Put(1, "foo", "v4");
+    Put(1, "foo", "v5");
+    ASSERT_EQ(AllEntriesFor("foo", 1), "[ v5, v4 ]");
+    ASSERT_OK(Flush(1));
+    ASSERT_EQ(AllEntriesFor("foo", 1), "[ v5 ]");
+    dbfull()->CompactRange(CompactRangeOptions(), handles_[1], nullptr,
                            nullptr);
-    ASSERT_EQ(AllEntriesFor("foo", 0), "[ v5 ]");
+    ASSERT_EQ(AllEntriesFor("foo", 1), "[ v5 ]");
 
     // clear database
-    Delete("foo");
-    dbfull()->CompactRange(CompactRangeOptions(), nullptr,
+    Delete(1, "foo");
+    dbfull()->CompactRange(CompactRangeOptions(), handles_[1], nullptr,
                            nullptr);
-    ASSERT_EQ(AllEntriesFor("foo", 0), "[ ]");
+    ASSERT_EQ(AllEntriesFor("foo", 1), "[ ]");
 
     // Case 5: Put followed by snapshot followed by another Put
     // Both puts should remain.
-    Put("foo", "v6");
+    Put(1, "foo", "v6");
     const Snapshot* snapshot = db_->GetSnapshot();
-    Put("foo", "v7");
-    ASSERT_OK(Flush(0));
-    ASSERT_EQ(AllEntriesFor("foo", 0), "[ v7, v6 ]");
+    Put(1, "foo", "v7");
+    ASSERT_OK(Flush(1));
+    ASSERT_EQ(AllEntriesFor("foo", 1), "[ v7, v6 ]");
     db_->ReleaseSnapshot(snapshot);
 
     // clear database
-    Delete("foo");
-    dbfull()->CompactRange(CompactRangeOptions(), nullptr,
+    Delete(1, "foo");
+    dbfull()->CompactRange(CompactRangeOptions(), handles_[1], nullptr,
                            nullptr);
-    ASSERT_EQ(AllEntriesFor("foo", 0), "[ ]");
+    ASSERT_EQ(AllEntriesFor("foo", 1), "[ ]");
 
     // Case 5: snapshot followed by a put followed by another Put
     // Only the last put should remain.
     const Snapshot* snapshot1 = db_->GetSnapshot();
-    Put("foo", "v8");
-    Put("foo", "v9");
-    ASSERT_OK(Flush(0));
-    ASSERT_EQ(AllEntriesFor("foo", 0), "[ v9 ]");
+    Put(1, "foo", "v8");
+    Put(1, "foo", "v9");
+    ASSERT_OK(Flush(1));
+    ASSERT_EQ(AllEntriesFor("foo", 1), "[ v9 ]");
     db_->ReleaseSnapshot(snapshot1);
   } while (ChangeCompactOptions());
 }
 
-TEST_F(DBBasicTest, DISABLED_FlushOneColumnFamily) {
+TEST_F(DBBasicTest, FlushOneColumnFamily) {
   Options options = CurrentOptions();
   CreateAndReopenWithCF({"pikachu", "ilya", "muromec", "dobrynia", "nikitich",
                          "alyosha", "popovich"},
@@ -753,21 +724,23 @@ TEST_F(DBBasicTest, DISABLED_FlushOneColumnFamily) {
 
 TEST_F(DBBasicTest, MultiGetSimple) {
   do {
+    CreateAndReopenWithCF({"pikachu"}, CurrentOptions());
     SetPerfLevel(kEnableCount);
-    ASSERT_OK(Put("k1", "v1"));
-    ASSERT_OK(Put("k2", "v2"));
-    ASSERT_OK(Put("k3", "v3"));
-    ASSERT_OK(Put("k4", "v4"));
-    ASSERT_OK(Delete("k4"));
-    ASSERT_OK(Put("k5", "v5"));
-    ASSERT_OK(Delete("no_key"));
+    ASSERT_OK(Put(1, "k1", "v1"));
+    ASSERT_OK(Put(1, "k2", "v2"));
+    ASSERT_OK(Put(1, "k3", "v3"));
+    ASSERT_OK(Put(1, "k4", "v4"));
+    ASSERT_OK(Delete(1, "k4"));
+    ASSERT_OK(Put(1, "k5", "v5"));
+    ASSERT_OK(Delete(1, "no_key"));
 
     std::vector<Slice> keys({"k1", "k2", "k3", "k4", "k5", "no_key"});
 
     std::vector<std::string> values(20, "Temporary data to be overwritten");
+    std::vector<ColumnFamilyHandle*> cfs(keys.size(), handles_[1]);
 
     get_perf_context()->Reset();
-    std::vector<Status> s = db_->MultiGet(ReadOptions(), keys, &values);
+    std::vector<Status> s = db_->MultiGet(ReadOptions(), cfs, keys, &values);
     ASSERT_EQ(values.size(), keys.size());
     ASSERT_EQ(values[0], "v1");
     ASSERT_EQ(values[1], "v2");

--- a/db/db_block_cache_test.cc
+++ b/db/db_block_cache_test.cc
@@ -50,7 +50,7 @@ class DBBlockCacheTest : public DBTestBase {
   void InitTable(const Options& options) {
     std::string value(kValueSize, 'a');
     for (size_t i = 0; i < kNumBlocks; i++) {
-      ASSERT_OK(Put(ToString(i), value.c_str(), WriteOptions(), false));
+      ASSERT_OK(Put(ToString(i), value.c_str()));
     }
   }
 

--- a/db/db_filesnapshot.cc
+++ b/db/db_filesnapshot.cc
@@ -148,7 +148,9 @@ Status DBImpl::GetLiveFiles(std::vector<std::string>& ret,
 Status DBImpl::GetLiveFilesQuick(std::vector<std::string>& ret,
                                  uint64_t* manifest_file_size,
                                  SequenceNumber* last_sequence,
-                                 uint64_t* last_decree) {
+                                 uint64_t* last_decree) const {
+  // ATTENTION(laiyingchun): only used for Pegasus.
+  assert(pegasus_data_);
   *manifest_file_size = 0;
   *last_sequence = 0;
   *last_decree = 0;

--- a/db/db_flush_test.cc
+++ b/db/db_flush_test.cc
@@ -68,7 +68,7 @@ TEST_F(DBFlushTest, SyncFail) {
   SyncPoint::GetInstance()->EnableProcessing();
 
   Reopen(options);
-  Put("key", "value", WriteOptions(), false);
+  Put("key", "value");
   auto* cfd =
       reinterpret_cast<ColumnFamilyHandleImpl*>(db_->DefaultColumnFamily())
           ->cfd();

--- a/db/db_impl.cc
+++ b/db/db_impl.cc
@@ -195,6 +195,7 @@ DBImpl::DBImpl(const DBOptions& options, const std::string& dbname)
       concurrent_prepare_(options.concurrent_prepare),
       manual_wal_flush_(options.manual_wal_flush),
       seq_per_batch_(options.seq_per_batch),
+      pegasus_data_(options.pegasus_data),
       // TODO(myabandeh): revise this when we change options.seq_per_batch
       use_custom_gc_(options.seq_per_batch),
       preserve_deletes_(options.preserve_deletes) {
@@ -750,31 +751,31 @@ SequenceNumber DBImpl::GetLatestSequenceNumber() const {
   return versions_->LastSequence();
 }
 
-uint64_t DBImpl::GetLastFlushedDecree() {
+uint64_t DBImpl::GetLastFlushedDecree() const {
   SequenceNumber seq;
   uint64_t d;
 
   mutex_.Lock();
   // ATTENTION(qinzuoyan): only use default column family.
-  assert(versions_->GetColumnFamilySet()->NumberOfColumnFamilies() == 1u);
+  assert(!pegasus_data_ || versions_->GetColumnFamilySet()->NumberOfColumnFamilies() == 1u);
   versions_->GetColumnFamilySet()->GetDefault()->current()->GetLastFlushSeqDecree(&seq, &d);
   mutex_.Unlock();
 
   return d;
 }
 
-uint32_t DBImpl::GetValueSchemaVersion() {
-    mutex_.Lock();
-    uint32_t version = versions_->GetColumnFamilySet()->GetValueSchemaVersion();
-    mutex_.Unlock();
-    return version;
+uint32_t DBImpl::GetPegasusDataVersion() const {
+  mutex_.Lock();
+  uint32_t version = versions_->GetColumnFamilySet()->GetPegasusDataVersion();
+  mutex_.Unlock();
+  return version;
 }
 
-uint64_t DBImpl::GetLastManualCompactFinishTime() {
-    mutex_.Lock();
-    uint64_t ms = versions_->GetColumnFamilySet()->GetLastManualCompactFinishTime();
-    mutex_.Unlock();
-    return ms;
+uint64_t DBImpl::GetLastManualCompactFinishTime() const {
+  mutex_.Lock();
+  uint64_t ms = versions_->GetColumnFamilySet()->GetLastManualCompactFinishTime();
+  mutex_.Unlock();
+  return ms;
 }
 
 SequenceNumber DBImpl::IncAndFetchSequenceNumber() {

--- a/db/db_impl.h
+++ b/db/db_impl.h
@@ -231,11 +231,11 @@ class DBImpl : public DB {
   bool HasActiveSnapshotInRange(SequenceNumber lower_bound,
                                 SequenceNumber upper_bound);
 
-  virtual uint64_t GetLastFlushedDecree() override;
+  virtual uint64_t GetLastFlushedDecree() const override;
 
-  virtual uint32_t GetValueSchemaVersion() override;
+  virtual uint32_t GetPegasusDataVersion() const override;
 
-  virtual uint64_t GetLastManualCompactFinishTime() override;
+  virtual uint64_t GetLastManualCompactFinishTime() const override;
 
 #ifndef ROCKSDB_LITE
   using DB::ResetStats;
@@ -250,7 +250,7 @@ class DBImpl : public DB {
   virtual Status GetLiveFilesQuick(std::vector<std::string>& ret,
                                    uint64_t* manifest_file_size,
                                    SequenceNumber* last_sequence,
-                                   uint64_t* last_decree) override;
+                                   uint64_t* last_decree) const override;
   virtual Status GetSortedWalFiles(VectorLogPtr& files) override;
 
   virtual Status GetUpdatesSince(
@@ -1334,6 +1334,7 @@ class DBImpl : public DB {
   const bool concurrent_prepare_;
   const bool manual_wal_flush_;
   const bool seq_per_batch_;
+  const bool pegasus_data_;
   const bool use_custom_gc_;
 
   // Clients must periodically call SetPreserveDeletesSequenceNumber()

--- a/db/db_impl_compaction_flush.cc
+++ b/db/db_impl_compaction_flush.cc
@@ -987,7 +987,9 @@ Status DBImpl::FlushMemTable(ColumnFamilyData* cfd,
       return Status::OK();
     }
 
-    if (!cfd->mem()->IsEmpty()) {
+    // ATTENTION(laiyingchun): An optimization to avoid switching empty memtable
+    // for Pegasus(single CF).
+    if (!pegasus_data_ || !cfd->mem()->IsEmpty()) {
       WriteThread::Writer w;
       if (!writes_stopped) {
         write_thread_.EnterUnbatched(&w, &mutex_);

--- a/db/db_impl_open.cc
+++ b/db/db_impl_open.cc
@@ -221,7 +221,7 @@ Status DBImpl::NewDB() {
   new_db.SetLogNumber(0);
   new_db.SetNextFile(2);
   new_db.SetLastSequence(0);
-  new_db.SetValueSchemaVersion(immutable_db_options_.default_value_schema_version);
+  new_db.SetPegasusDataVersion(immutable_db_options_.pegasus_data_version);
 
   Status s;
 

--- a/db/db_impl_write.cc
+++ b/db/db_impl_write.cc
@@ -81,7 +81,7 @@ Status DBImpl::WriteImpl(const WriteOptions& write_options,
 
   // ATTENTION(qinzuoyan): always only use default column family under
   // replication framework.
-  //assert(single_column_family_mode_);
+  assert(!pegasus_data_ || single_column_family_mode_);
 
   Status status;
   if (write_options.low_pri) {
@@ -92,14 +92,14 @@ Status DBImpl::WriteImpl(const WriteOptions& write_options,
   }
 
   // ATTENTION(laiyingchun): disable_memtable is always false in pegasus
-  assert(!disable_memtable);
+  assert(!pegasus_data_ || !disable_memtable);
   if (concurrent_prepare_ && disable_memtable) {
     return WriteImplWALOnly(write_options, my_batch, callback, log_used,
                             log_ref, seq_used);
   }
 
   // ATTENTION(laiyingchun): enable_pipelined_write is always false in pegasus
-  assert(!immutable_db_options_.enable_pipelined_write);
+  assert(!pegasus_data_ || !immutable_db_options_.enable_pipelined_write);
   if (immutable_db_options_.enable_pipelined_write) {
     return PipelinedWriteImpl(write_options, my_batch, callback, log_used,
                               log_ref, disable_memtable, seq_used);
@@ -119,7 +119,7 @@ Status DBImpl::WriteImpl(const WriteOptions& write_options,
   // ATTENTION(qinzuoyan): because write is always applied in single thread
   // under replication framework, so we must be the only write batch and
   // must be STATE_GROUP_LEADER.
-  assert(w.state == WriteThread::STATE_GROUP_LEADER);
+  assert(!pegasus_data_ || w.state == WriteThread::STATE_GROUP_LEADER);
   if (w.state == WriteThread::STATE_PARALLEL_MEMTABLE_WRITER) {
     // we are a non-leader in a parallel group
     PERF_TIMER_GUARD(write_memtable_time);
@@ -195,7 +195,7 @@ Status DBImpl::WriteImpl(const WriteOptions& write_options,
   if (status.ok()) {
     // ATTENTION(qinzuoyan): because write is always applied in single thread
     // under replication framework, so we must be the only write batch.
-    assert(write_group.size == 1);
+    assert(!pegasus_data_ || write_group.size == 1);
 
     // Rules for when we can update the memtable concurrently
     // 1. supported by memtable
@@ -225,13 +225,12 @@ Status DBImpl::WriteImpl(const WriteOptions& write_options,
     }
 
     // ATTENTION(qinzuoyan): under replication framework, batch should not be empty.
-    assert(total_count > 0);
+    assert(!pegasus_data_ || total_count > 0);
     // ATTENTION(laiyingchun): seq_per_batch_ should always be false as default value.
-    assert(!seq_per_batch_);
+    assert(!pegasus_data_ || !seq_per_batch_);
     size_t seq_inc = seq_per_batch_ ? write_group.size : total_count;
 
     const bool concurrent_update = concurrent_prepare_;
-
     // Update stats while we are an exclusive group leader, so we know
     // that nobody else can be writing to these particular stats.
     // We're optimistic, updating the stats before we successfully
@@ -278,21 +277,20 @@ Status DBImpl::WriteImpl(const WriteOptions& write_options,
       }
     }
     assert(last_sequence != kMaxSequenceNumber);
-    const SequenceNumber current_sequence = write_options.given_sequence_number == 0 ?
-                                            (last_sequence + 1) : write_options.given_sequence_number;
-    last_sequence = current_sequence + seq_inc - 1;
+    const SequenceNumber current_sequence = last_sequence + 1;
+    last_sequence += seq_inc;
 
     if (status.ok()) {
       PERF_TIMER_GUARD(write_memtable_time);
 
       // ATTENTION(laiyingchun): parallel should always be false because write_group.size == 1.
-      assert(!parallel);
+      assert(!pegasus_data_ || !parallel);
       if (!parallel) {
         w.status = WriteBatchInternal::InsertInto(
             write_group, current_sequence, column_family_memtables_.get(),
             &flush_scheduler_, write_options.ignore_missing_column_families,
             0 /*recovery_log_number*/, this, parallel, seq_per_batch_,
-            write_options.given_decree);
+            write_options.given_decree, pegasus_data_);
       } else {
         SequenceNumber next_sequence = current_sequence;
         for (auto* writer : write_group) {

--- a/db/db_inplace_update_test.cc
+++ b/db/db_inplace_update_test.cc
@@ -25,18 +25,18 @@ TEST_F(DBTestInPlaceUpdate, InPlaceUpdate) {
     options.write_buffer_size = 100000;
     options.allow_concurrent_memtable_write = false;
     Reopen(options);
-    //CreateAndReopenWithCF({"pikachu"}, options);
+    CreateAndReopenWithCF({"pikachu"}, options);
 
     // Update key with values of smaller size
     int numValues = 10;
     for (int i = numValues; i > 0; i--) {
       std::string value = DummyString(i, 'a');
-      ASSERT_OK(Put("key", value));
-      ASSERT_EQ(value, Get("key"));
+      ASSERT_OK(Put(1, "key", value));
+      ASSERT_EQ(value, Get(1, "key"));
     }
 
     // Only 1 instance for that key.
-    validateNumberOfEntries(1, 0);
+    validateNumberOfEntries(1, 1);
   } while (ChangeCompactOptions());
 }
 
@@ -49,18 +49,18 @@ TEST_F(DBTestInPlaceUpdate, InPlaceUpdateLargeNewValue) {
     options.write_buffer_size = 100000;
     options.allow_concurrent_memtable_write = false;
     Reopen(options);
-    //CreateAndReopenWithCF({"pikachu"}, options);
+    CreateAndReopenWithCF({"pikachu"}, options);
 
     // Update key with values of larger size
     int numValues = 10;
     for (int i = 0; i < numValues; i++) {
       std::string value = DummyString(i, 'a');
-      ASSERT_OK(Put("key", value));
-      ASSERT_EQ(value, Get("key"));
+      ASSERT_OK(Put(1, "key", value));
+      ASSERT_EQ(value, Get(1, "key"));
     }
 
     // All 10 updates exist in the internal iterator
-    validateNumberOfEntries(numValues, 0);
+    validateNumberOfEntries(numValues, 1);
   } while (ChangeCompactOptions());
 }
 
@@ -76,20 +76,20 @@ TEST_F(DBTestInPlaceUpdate, InPlaceUpdateCallbackSmallerSize) {
       rocksdb::DBTestInPlaceUpdate::updateInPlaceSmallerSize;
     options.allow_concurrent_memtable_write = false;
     Reopen(options);
-    //CreateAndReopenWithCF({"pikachu"}, options);
+    CreateAndReopenWithCF({"pikachu"}, options);
 
     // Update key with values of smaller size
     int numValues = 10;
-    ASSERT_OK(Put("key", DummyString(numValues, 'a')));
-    ASSERT_EQ(DummyString(numValues, 'c'), Get("key"));
+    ASSERT_OK(Put(1, "key", DummyString(numValues, 'a')));
+    ASSERT_EQ(DummyString(numValues, 'c'), Get(1, "key"));
 
     for (int i = numValues; i > 0; i--) {
-      ASSERT_OK(Put("key", DummyString(i, 'a')));
-      ASSERT_EQ(DummyString(i - 1, 'b'), Get("key"));
+      ASSERT_OK(Put(1, "key", DummyString(i, 'a')));
+      ASSERT_EQ(DummyString(i - 1, 'b'), Get(1, "key"));
     }
 
     // Only 1 instance for that key.
-    validateNumberOfEntries(1, 0);
+    validateNumberOfEntries(1, 1);
   } while (ChangeCompactOptions());
 }
 
@@ -105,20 +105,20 @@ TEST_F(DBTestInPlaceUpdate, InPlaceUpdateCallbackSmallerVarintSize) {
       rocksdb::DBTestInPlaceUpdate::updateInPlaceSmallerVarintSize;
     options.allow_concurrent_memtable_write = false;
     Reopen(options);
-    //CreateAndReopenWithCF({"pikachu"}, options);
+    CreateAndReopenWithCF({"pikachu"}, options);
 
     // Update key with values of smaller varint size
     int numValues = 265;
-    ASSERT_OK(Put("key", DummyString(numValues, 'a')));
-    ASSERT_EQ(DummyString(numValues, 'c'), Get("key"));
+    ASSERT_OK(Put(1, "key", DummyString(numValues, 'a')));
+    ASSERT_EQ(DummyString(numValues, 'c'), Get(1, "key"));
 
     for (int i = numValues; i > 0; i--) {
-      ASSERT_OK(Put("key", DummyString(i, 'a')));
-      ASSERT_EQ(DummyString(1, 'b'), Get("key"));
+      ASSERT_OK(Put(1, "key", DummyString(i, 'a')));
+      ASSERT_EQ(DummyString(1, 'b'), Get(1, "key"));
     }
 
     // Only 1 instance for that key.
-    validateNumberOfEntries(1, 0);
+    validateNumberOfEntries(1, 1);
   } while (ChangeCompactOptions());
 }
 
@@ -134,18 +134,18 @@ TEST_F(DBTestInPlaceUpdate, InPlaceUpdateCallbackLargeNewValue) {
       rocksdb::DBTestInPlaceUpdate::updateInPlaceLargerSize;
     options.allow_concurrent_memtable_write = false;
     Reopen(options);
-    //CreateAndReopenWithCF({"pikachu"}, options);
+    CreateAndReopenWithCF({"pikachu"}, options);
 
     // Update key with values of larger size
     int numValues = 10;
     for (int i = 0; i < numValues; i++) {
-      ASSERT_OK(Put("key", DummyString(i, 'a')));
-      ASSERT_EQ(DummyString(i, 'c'), Get("key"));
+      ASSERT_OK(Put(1, "key", DummyString(i, 'a')));
+      ASSERT_EQ(DummyString(i, 'c'), Get(1, "key"));
     }
 
     // No inplace updates. All updates are puts with new seq number
     // All 10 updates exist in the internal iterator
-    validateNumberOfEntries(numValues, 0);
+    validateNumberOfEntries(numValues, 1);
   } while (ChangeCompactOptions());
 }
 
@@ -161,11 +161,11 @@ TEST_F(DBTestInPlaceUpdate, InPlaceUpdateCallbackNoAction) {
         rocksdb::DBTestInPlaceUpdate::updateInPlaceNoAction;
     options.allow_concurrent_memtable_write = false;
     Reopen(options);
-    //CreateAndReopenWithCF({"pikachu"}, options);
+    CreateAndReopenWithCF({"pikachu"}, options);
 
     // Callback function requests no actions from db
-    ASSERT_OK(Put("key", DummyString(1, 'a')));
-    ASSERT_EQ(Get("key"), "NOT_FOUND");
+    ASSERT_OK(Put(1, "key", DummyString(1, 'a')));
+    ASSERT_EQ(Get(1, "key"), "NOT_FOUND");
   } while (ChangeCompactOptions());
 }
 }  // namespace rocksdb

--- a/db/db_log_iter_test.cc
+++ b/db/db_log_iter_test.cc
@@ -17,10 +17,9 @@
 
 namespace rocksdb {
 
-// NOTE: WAL is disable in pegasus, so ignore these test cases.
-class DISABLED_DBTestXactLogIterator : public DBTestBase {
+class DBTestXactLogIterator : public DBTestBase {
  public:
-  DISABLED_DBTestXactLogIterator() : DBTestBase("/db_log_iter_test") {}
+  DBTestXactLogIterator() : DBTestBase("/db_log_iter_test") {}
 
   std::unique_ptr<TransactionLogIterator> OpenTransactionLogIter(
       const SequenceNumber seq) {
@@ -59,7 +58,7 @@ void ExpectRecords(
 }
 }  // namespace
 
-TEST_F(DISABLED_DBTestXactLogIterator, TransactionLogIterator) {
+TEST_F(DBTestXactLogIterator, TransactionLogIterator) {
   do {
     Options options = OptionsForLogIterTest();
     DestroyAndReopen(options);
@@ -87,7 +86,7 @@ TEST_F(DISABLED_DBTestXactLogIterator, TransactionLogIterator) {
 }
 
 #ifndef NDEBUG  // sync point is not included with DNDEBUG build
-TEST_F(DISABLED_DBTestXactLogIterator, TransactionLogIteratorRace) {
+TEST_F(DBTestXactLogIterator, TransactionLogIteratorRace) {
   static const int LOG_ITERATOR_RACE_TEST_COUNT = 2;
   static const char* sync_points[LOG_ITERATOR_RACE_TEST_COUNT][4] = {
       {"WalManager::GetSortedWalFiles:1",  "WalManager::PurgeObsoleteFiles:1",
@@ -145,7 +144,7 @@ TEST_F(DISABLED_DBTestXactLogIterator, TransactionLogIteratorRace) {
 }
 #endif
 
-TEST_F(DISABLED_DBTestXactLogIterator, TransactionLogIteratorStallAtLastRecord) {
+TEST_F(DBTestXactLogIterator, TransactionLogIteratorStallAtLastRecord) {
   do {
     Options options = OptionsForLogIterTest();
     DestroyAndReopen(options);
@@ -163,7 +162,7 @@ TEST_F(DISABLED_DBTestXactLogIterator, TransactionLogIteratorStallAtLastRecord) 
   } while (ChangeCompactOptions());
 }
 
-TEST_F(DISABLED_DBTestXactLogIterator, TransactionLogIteratorCheckAfterRestart) {
+TEST_F(DBTestXactLogIterator, TransactionLogIteratorCheckAfterRestart) {
   do {
     Options options = OptionsForLogIterTest();
     DestroyAndReopen(options);
@@ -176,7 +175,7 @@ TEST_F(DISABLED_DBTestXactLogIterator, TransactionLogIteratorCheckAfterRestart) 
   } while (ChangeCompactOptions());
 }
 
-TEST_F(DISABLED_DBTestXactLogIterator, TransactionLogIteratorCorruptedLog) {
+TEST_F(DBTestXactLogIterator, TransactionLogIteratorCorruptedLog) {
   do {
     Options options = OptionsForLogIterTest();
     DestroyAndReopen(options);
@@ -211,7 +210,7 @@ TEST_F(DISABLED_DBTestXactLogIterator, TransactionLogIteratorCorruptedLog) {
   } while (ChangeCompactOptions());
 }
 
-TEST_F(DISABLED_DBTestXactLogIterator, TransactionLogIteratorBatchOperations) {
+TEST_F(DBTestXactLogIterator, TransactionLogIteratorBatchOperations) {
   do {
     Options options = OptionsForLogIterTest();
     DestroyAndReopen(options);
@@ -231,7 +230,7 @@ TEST_F(DISABLED_DBTestXactLogIterator, TransactionLogIteratorBatchOperations) {
   } while (ChangeCompactOptions());
 }
 
-TEST_F(DISABLED_DBTestXactLogIterator, TransactionLogIteratorBlobs) {
+TEST_F(DBTestXactLogIterator, TransactionLogIteratorBlobs) {
   Options options = OptionsForLogIterTest();
   DestroyAndReopen(options);
   CreateAndReopenWithCF({"pikachu"}, options);

--- a/db/db_memtable_test.cc
+++ b/db/db_memtable_test.cc
@@ -175,9 +175,9 @@ TEST_F(DBMemTableTest, ColumnFamilyId) {
   options.create_if_missing = true;
   options.memtable_factory.reset(new MockMemTableRepFactory());
   DestroyAndReopen(options);
-  //CreateAndReopenWithCF({"pikachu"}, options);
+  CreateAndReopenWithCF({"pikachu"}, options);
 
-  for (int cf = 0; cf < 1; ++cf) {
+  for (int cf = 0; cf < 2; ++cf) {
     ASSERT_OK(Put(cf, "key", "val"));
     ASSERT_OK(Flush(cf));
     ASSERT_EQ(

--- a/db/db_merge_operator_test.cc
+++ b/db/db_merge_operator_test.cc
@@ -282,7 +282,7 @@ TEST_P(MergeOperatorPinningTest, Randomized) {
     VerifyDBFromMap(true_data);
 
     // Skip HashCuckoo since it does not support merge operators
-  } while (ChangeOptions(kSkipMergePut | kSkipHashCuckoo | kSkipPipelinedWrite));
+  } while (ChangeOptions(kSkipMergePut | kSkipHashCuckoo));
 }
 
 class MergeOperatorHook : public MergeOperator {

--- a/db/db_options_test.cc
+++ b/db/db_options_test.cc
@@ -190,7 +190,7 @@ TEST_F(DBOptionsTest, SetWalBytesPerSync) {
   const std::string kValue(kValueSize, 'v');
   int i = 0;
   for (; i < 10; i++) {
-    Put(Key(i), kValue, WriteOptions(), false);
+    Put(Key(i), kValue);
   }
   // Do not flush. If we flush here, SwitchWAL will reuse old WAL file since its
   // empty and will not get the new wal_bytes_per_sync value.
@@ -201,7 +201,7 @@ TEST_F(DBOptionsTest, SetWalBytesPerSync) {
   counter = 0;
   i = 0;
   for (; i < 10; i++) {
-    Put(Key(i), kValue, WriteOptions(), false);
+    Put(Key(i), kValue);
   }
   ASSERT_GT(counter, 0);
   ASSERT_GT(low_bytes_per_sync, 0);
@@ -234,8 +234,8 @@ TEST_F(DBOptionsTest, WritableFileMaxBufferSize) {
   rocksdb::SyncPoint::GetInstance()->EnableProcessing();
   int i = 0;
   for (; i < 3; i++) {
-    ASSERT_OK(Put("foo", ToString(i), WriteOptions(), false));
-    ASSERT_OK(Put("bar", ToString(i), WriteOptions(), false));
+    ASSERT_OK(Put("foo", ToString(i)));
+    ASSERT_OK(Put("bar", ToString(i)));
     Flush();
   }
   dbfull()->TEST_WaitForCompact();
@@ -251,8 +251,8 @@ TEST_F(DBOptionsTest, WritableFileMaxBufferSize) {
             dbfull()->GetDBOptions().writable_file_max_buffer_size);
   i = 0;
   for (; i < 3; i++) {
-    ASSERT_OK(Put("foo", ToString(i), WriteOptions(), false));
-    ASSERT_OK(Put("bar", ToString(i), WriteOptions(), false));
+    ASSERT_OK(Put("foo", ToString(i)));
+    ASSERT_OK(Put("bar", ToString(i)));
     Flush();
   }
   dbfull()->TEST_WaitForCompact();
@@ -478,8 +478,8 @@ TEST_F(DBOptionsTest, MaxTotalWalSizeChange) {
   Options options;
   options.create_if_missing = true;
   options.env = env_;
-  //CreateColumnFamilies({"1", "2", "3"}, options);
-  ReopenWithColumnFamilies({"default"/*, "1", "2", "3"*/}, options);
+  CreateColumnFamilies({"1", "2", "3"}, options);
+  ReopenWithColumnFamilies({"default", "1", "2", "3"}, options);
 
   WriteOptions write_options;
 

--- a/db/db_sst_test.cc
+++ b/db/db_sst_test.cc
@@ -158,7 +158,7 @@ TEST_F(DBSSTTest, DeleteObsoleteFilesPendingOutputs) {
   for (int i = 0; i < 2; ++i) {
     // Create 1MB sst file
     for (int j = 0; j < 100; ++j) {
-      ASSERT_OK(Put(Key(i * 50 + j), RandomString(&rnd, 10 * 1024), WriteOptions(), false));
+      ASSERT_OK(Put(Key(i * 50 + j), RandomString(&rnd, 10 * 1024)));
     }
     ASSERT_OK(Flush());
   }
@@ -189,7 +189,7 @@ TEST_F(DBSSTTest, DeleteObsoleteFilesPendingOutputs) {
   // write_buffer_size. The flush will be blocked with block_first_time
   // pending_file is protecting all the files created after
   for (int j = 0; j < 256; ++j) {
-    ASSERT_OK(Put(Key(j), RandomString(&rnd, 10 * 1024), WriteOptions(), false));
+    ASSERT_OK(Put(Key(j), RandomString(&rnd, 10 * 1024)));
   }
   blocking_thread.WaitUntilSleeping();
 

--- a/db/db_test_util.h
+++ b/db/db_test_util.h
@@ -723,7 +723,6 @@ class DBTestBase : public testing::Test {
     kSkipHashCuckoo = 64,
     kSkipFIFOCompaction = 128,
     kSkipMmapReads = 256,
-    kSkipPipelinedWrite = 512,
   };
 
   explicit DBTestBase(const std::string path);
@@ -809,9 +808,9 @@ class DBTestBase : public testing::Test {
 
   bool IsMemoryMappedAccessSupported() const;
 
-  Status Flush(int cf = 0, const FlushOptions& options = FlushOptions());
+  Status Flush(int cf = 0);
 
-  Status Put(const Slice& k, const Slice& v, WriteOptions wo = WriteOptions(), bool disableWAL = true);
+  Status Put(const Slice& k, const Slice& v, WriteOptions wo = WriteOptions());
 
   Status Put(int cf, const Slice& k, const Slice& v,
              WriteOptions wo = WriteOptions());
@@ -902,7 +901,7 @@ class DBTestBase : public testing::Test {
   int GetSstFileCount(std::string path);
 
   // this will generate non-overlapping files since it keeps increasing key_idx
-  void GenerateNewFile(Random* rnd, int* key_idx, bool nowait = false, bool disableWAL = true);
+  void GenerateNewFile(Random* rnd, int* key_idx, bool nowait = false);
 
   void GenerateNewFile(int fd, Random* rnd, int* key_idx, bool nowait = false);
 

--- a/db/db_write_test.cc
+++ b/db/db_write_test.cc
@@ -52,7 +52,7 @@ TEST_P(DBWriteTest, ReturnSeuqneceNumber) {
   }
 }
 
-TEST_P(DBWriteTest, DISABLED_ReturnSeuqneceNumberMultiThreaded) {
+TEST_P(DBWriteTest, ReturnSeuqneceNumberMultiThreaded) {
   constexpr size_t kThreads = 16;
   constexpr size_t kNumKeys = 1000;
   Open();
@@ -85,7 +85,7 @@ TEST_P(DBWriteTest, DISABLED_ReturnSeuqneceNumberMultiThreaded) {
   }
 }
 
-TEST_P(DBWriteTest, DISABLED_IOErrorOnWALWritePropagateToWriteThreadFollower) {
+TEST_P(DBWriteTest, IOErrorOnWALWritePropagateToWriteThreadFollower) {
   constexpr int kNumThreads = 5;
   std::unique_ptr<FaultInjectionTestEnv> mock_env(
       new FaultInjectionTestEnv(Env::Default()));
@@ -128,8 +128,8 @@ TEST_P(DBWriteTest, DISABLED_IOErrorOnWALWritePropagateToWriteThreadFollower) {
 
 INSTANTIATE_TEST_CASE_P(DBWriteTestInstance, DBWriteTest,
                         testing::Values(DBTestBase::kDefault,
-                                        DBTestBase::kConcurrentWALWrites/*,
-                                        DBTestBase::kPipelinedWrite*/));
+                                        DBTestBase::kConcurrentWALWrites,
+                                        DBTestBase::kPipelinedWrite));
 
 }  // namespace rocksdb
 

--- a/db/external_sst_file_test.cc
+++ b/db/external_sst_file_test.cc
@@ -349,7 +349,7 @@ TEST_F(ExternalSSTFileTest, Basic) {
         std::string value = Key(k) + "_val";
         ASSERT_EQ(Get(Key(k)), value);
       }
-      ASSERT_TRUE(Flush().ok());
+      ASSERT_OK(Flush());
       ASSERT_OK(db_->CompactRange(CompactRangeOptions(), nullptr, nullptr));
     }
 
@@ -377,7 +377,7 @@ TEST_F(ExternalSSTFileTest, Basic) {
       ASSERT_EQ(Get(Key(k)), value);
     }
     DestroyAndRecreateExternalSSTFilesDir();
-  } while (ChangeOptions(kSkipPlainTable | kSkipFIFOCompaction | kSkipPipelinedWrite));
+  } while (ChangeOptions(kSkipPlainTable | kSkipFIFOCompaction));
 }
 class SstFileWriterCollector : public TablePropertiesCollector {
  public:
@@ -593,7 +593,7 @@ TEST_F(ExternalSSTFileTest, AddList) {
         std::string value = Key(k) + "_val";
         ASSERT_EQ(Get(Key(k)), value);
       }
-      ASSERT_TRUE(Flush().ok());
+      ASSERT_OK(Flush());
       ASSERT_OK(db_->CompactRange(CompactRangeOptions(), nullptr, nullptr));
     }
 
@@ -617,7 +617,7 @@ TEST_F(ExternalSSTFileTest, AddList) {
       ASSERT_EQ(Get(Key(k)), value);
     }
     DestroyAndRecreateExternalSSTFilesDir();
-  } while (ChangeOptions(kSkipPlainTable | kSkipFIFOCompaction | kSkipPipelinedWrite));
+  } while (ChangeOptions(kSkipPlainTable | kSkipFIFOCompaction));
 }
 
 TEST_F(ExternalSSTFileTest, AddListAtomicity) {
@@ -659,7 +659,7 @@ TEST_F(ExternalSSTFileTest, AddListAtomicity) {
       ASSERT_EQ(Get(Key(k)), value);
     }
     DestroyAndRecreateExternalSSTFilesDir();
-  } while (ChangeOptions(kSkipPlainTable | kSkipFIFOCompaction | kSkipPipelinedWrite));
+  } while (ChangeOptions(kSkipPlainTable | kSkipFIFOCompaction));
 }
 // This test reporduce a bug that can happen in some cases if the DB started
 // purging obsolete files when we are adding an external sst file.
@@ -884,13 +884,13 @@ TEST_F(ExternalSSTFileTest, MultiThreaded) {
         std::string value = (k % 100 == 0) ? (key + "_new") : key;
         ASSERT_EQ(Get(key), value);
       }
-      ASSERT_TRUE(Flush().ok());
+      ASSERT_OK(Flush());
       ASSERT_OK(db_->CompactRange(CompactRangeOptions(), nullptr, nullptr));
     }
 
     fprintf(stderr, "Verified %d values\n", num_files * keys_per_file);
     DestroyAndRecreateExternalSSTFilesDir();
-  } while (ChangeOptions(kSkipPlainTable | kSkipFIFOCompaction | kSkipPipelinedWrite));
+  } while (ChangeOptions(kSkipPlainTable | kSkipFIFOCompaction));
 }
 
 TEST_F(ExternalSSTFileTest, OverlappingRanges) {
@@ -1020,7 +1020,7 @@ TEST_F(ExternalSSTFileTest, OverlappingRanges) {
     }
     printf("keys/values verified\n");
     DestroyAndRecreateExternalSSTFilesDir();
-  } while (ChangeOptions(kSkipPlainTable | kSkipFIFOCompaction | kSkipPipelinedWrite));
+  } while (ChangeOptions(kSkipPlainTable | kSkipFIFOCompaction));
 }
 
 TEST_F(ExternalSSTFileTest, PickedLevel) {

--- a/db/fault_injection_test.cc
+++ b/db/fault_injection_test.cc
@@ -350,7 +350,7 @@ __attribute__((__no_sanitize_undefined__))
   }
 };
 
-TEST_P(FaultInjectionTest, DISABLED_FaultTest) {        // PEGASUS: we dont support WAL
+TEST_P(FaultInjectionTest, FaultTest) {
   do {
     Random rnd(301);
 
@@ -390,7 +390,7 @@ TEST_P(FaultInjectionTest, DISABLED_FaultTest) {        // PEGASUS: we dont supp
 }
 
 // Previous log file is not fsynced if sync is forced after log rolling.
-TEST_P(FaultInjectionTest, DISABLED_WriteOptionSyncTest) {        // PEGASUS: we dont support WAL
+TEST_P(FaultInjectionTest, WriteOptionSyncTest) {
   test::SleepingBackgroundTask sleeping_task_low;
   env_->SetBackgroundThreads(1, Env::HIGH);
   // Block the job queue to prevent flush job from running.
@@ -476,7 +476,7 @@ TEST_P(FaultInjectionTest, UninstalledCompaction) {
   rocksdb::SyncPoint::GetInstance()->ClearAllCallBacks();
 }
 
-TEST_P(FaultInjectionTest, DISABLED_ManualLogSyncTest) {        // PEGASUS: we dont support WAL
+TEST_P(FaultInjectionTest, ManualLogSyncTest) {
   test::SleepingBackgroundTask sleeping_task_low;
   env_->SetBackgroundThreads(1, Env::HIGH);
   // Block the job queue to prevent flush job from running.
@@ -513,7 +513,7 @@ TEST_P(FaultInjectionTest, DISABLED_ManualLogSyncTest) {        // PEGASUS: we d
   ASSERT_EQ(value_space, val);
 }
 
-TEST_P(FaultInjectionTest, DISABLED_WriteBatchWalTerminationTest) {        // PEGASUS: we dont support WAL
+TEST_P(FaultInjectionTest, WriteBatchWalTerminationTest) {
   ReadOptions ro;
   Options options = CurrentOptions();
   options.env = env_;

--- a/db/flush_job.cc
+++ b/db/flush_job.cc
@@ -147,14 +147,16 @@ void FlushJob::PickMemTable() {
   // will no longer be picked up for recovery.
   edit_->SetLogNumber(mems_.back()->GetNextLogNumber());
   edit_->SetColumnFamily(cfd_->GetID());
-  // Mark the last sequence/decree of all memtables to be flushed. Although
-  // entries mems are sorted in ascending order by their created, we should
-  // iterate all mems but not take the last one because memtable may be empty.
-  for (auto mem : mems_) {
-    SequenceNumber seq;
-    uint64_t d;
-    mem->GetLastSeqDecree(&seq, &d);
-    edit_->UpdateLastFlushSeqDecree(seq, d);
+  if (db_options_.pegasus_data) {
+    // Mark the last sequence/decree of all memtables to be flushed. Although
+    // entries mems are sorted in ascending order by their created, we should
+    // iterate all mems but not take the last one because memtable may be empty.
+    for (auto mem : mems_) {
+      SequenceNumber seq;
+      uint64_t d;
+      mem->GetLastSeqDecree(&seq, &d);
+      edit_->UpdateLastFlushSeqDecree(seq, d);
+    }
   }
 
   // path 0 for level 0 file.

--- a/db/flush_job_test.cc
+++ b/db/flush_job_test.cc
@@ -54,7 +54,6 @@ class FlushJobTest : public testing::Test {
     new_db.SetLogNumber(0);
     new_db.SetNextFile(2);
     new_db.SetLastSequence(0);
-    new_db.SetValueSchemaVersion(0);
 
     const std::string manifest = DescriptorFileName(dbname_, 1);
     unique_ptr<WritableFile> file;

--- a/db/memtable.h
+++ b/db/memtable.h
@@ -368,7 +368,7 @@ class MemTable {
     return oldest_key_time_.load(std::memory_order_relaxed);
   }
 
-  void GetLastSeqDecree(SequenceNumber* sequence, uint64_t* decree) {
+  void GetLastSeqDecree(SequenceNumber* sequence, uint64_t* decree) const {
     *sequence = last_sequence_;
     *decree = last_decree_;
   }

--- a/db/repair_test.cc
+++ b/db/repair_test.cc
@@ -20,9 +20,9 @@
 namespace rocksdb {
 
 #ifndef ROCKSDB_LITE
-class DISABLED_RepairTest : public DBTestBase {
+class RepairTest : public DBTestBase {
  public:
-  DISABLED_RepairTest() : DBTestBase("/repair_test") {}
+  RepairTest() : DBTestBase("/repair_test") {}
 
   std::string GetFirstSstPath() {
     uint64_t manifest_size;
@@ -39,7 +39,7 @@ class DISABLED_RepairTest : public DBTestBase {
   }
 };
 
-TEST_F(DISABLED_RepairTest, LostManifest) {
+TEST_F(RepairTest, LostManifest) {
   // Add a couple SST files, delete the manifest, and verify RepairDB() saves
   // the day.
   Put("key", "val");
@@ -61,7 +61,7 @@ TEST_F(DISABLED_RepairTest, LostManifest) {
   ASSERT_EQ(Get("key2"), "val2");
 }
 
-TEST_F(DISABLED_RepairTest, CorruptManifest) {
+TEST_F(RepairTest, CorruptManifest) {
   // Manifest is in an invalid format. Expect a full recovery.
   Put("key", "val");
   Flush();
@@ -82,7 +82,7 @@ TEST_F(DISABLED_RepairTest, CorruptManifest) {
   ASSERT_EQ(Get("key2"), "val2");
 }
 
-TEST_F(DISABLED_RepairTest, IncompleteManifest) {
+TEST_F(RepairTest, IncompleteManifest) {
   // In this case, the manifest is valid but does not reference all of the SST
   // files. Expect a full recovery.
   Put("key", "val");
@@ -108,7 +108,7 @@ TEST_F(DISABLED_RepairTest, IncompleteManifest) {
   ASSERT_EQ(Get("key2"), "val2");
 }
 
-TEST_F(DISABLED_RepairTest, PostRepairSstFileNumbering) {
+TEST_F(RepairTest, PostRepairSstFileNumbering) {
   // Verify after a DB is repaired, new files will be assigned higher numbers
   // than old files.
   Put("key", "val");
@@ -125,7 +125,7 @@ TEST_F(DISABLED_RepairTest, PostRepairSstFileNumbering) {
   ASSERT_GE(post_repair_file_num, pre_repair_file_num);
 }
 
-TEST_F(DISABLED_RepairTest, LostSst) {
+TEST_F(RepairTest, LostSst) {
   // Delete one of the SST files but preserve the manifest that refers to it,
   // then verify the DB is still usable for the intact SST.
   Put("key", "val");
@@ -144,7 +144,7 @@ TEST_F(DISABLED_RepairTest, LostSst) {
   ASSERT_TRUE((Get("key") == "val") != (Get("key2") == "val2"));
 }
 
-TEST_F(DISABLED_RepairTest, CorruptSst) {
+TEST_F(RepairTest, CorruptSst) {
   // Corrupt one of the SST files but preserve the manifest that refers to it,
   // then verify the DB is still usable for the intact SST.
   Put("key", "val");
@@ -163,7 +163,7 @@ TEST_F(DISABLED_RepairTest, CorruptSst) {
   ASSERT_TRUE((Get("key") == "val") != (Get("key2") == "val2"));
 }
 
-TEST_F(DISABLED_RepairTest, UnflushedSst) {
+TEST_F(RepairTest, UnflushedSst) {
   // This test case invokes repair while some data is unflushed, then verifies
   // that data is in the db.
   Put("key", "val");
@@ -191,7 +191,7 @@ TEST_F(DISABLED_RepairTest, UnflushedSst) {
   ASSERT_EQ(Get("key"), "val");
 }
 
-TEST_F(DISABLED_RepairTest, SeparateWalDir) {
+TEST_F(RepairTest, SeparateWalDir) {
   do {
     Options options = CurrentOptions();
     DestroyAndReopen(options);
@@ -225,7 +225,7 @@ TEST_F(DISABLED_RepairTest, SeparateWalDir) {
  } while(ChangeWalOptions());
 }
 
-TEST_F(DISABLED_RepairTest, RepairMultipleColumnFamilies) {
+TEST_F(RepairTest, RepairMultipleColumnFamilies) {
   // Verify repair logic associates SST files with their original column
   // families.
   const int kNumCfs = 3;
@@ -263,7 +263,7 @@ TEST_F(DISABLED_RepairTest, RepairMultipleColumnFamilies) {
   }
 }
 
-TEST_F(DISABLED_RepairTest, RepairColumnFamilyOptions) {
+TEST_F(RepairTest, RepairColumnFamilyOptions) {
   // Verify repair logic uses correct ColumnFamilyOptions when repairing a
   // database with different options for column families.
   const int kNumCfs = 2;
@@ -326,12 +326,12 @@ TEST_F(DISABLED_RepairTest, RepairColumnFamilyOptions) {
   }
 }
 
-TEST_F(DISABLED_RepairTest, DbNameContainsTrailingSlash) {
+TEST_F(RepairTest, DbNameContainsTrailingSlash) {
   {
     bool tmp;
     if (env_->AreFilesSame("", "", &tmp).IsNotSupported()) {
       fprintf(stderr,
-              "skipping DISABLED_RepairTest.DbNameContainsTrailingSlash due to "
+              "skipping RepairTest.DbNameContainsTrailingSlash due to "
               "unsupported Env::AreFilesSame\n");
       return;
     }

--- a/db/version_edit.cc
+++ b/db/version_edit.cc
@@ -366,7 +366,7 @@ Status VersionEdit::DecodeFrom(const Slice& src) {
         if (GetVarint32(&input, &pegasus_data_version_)) {
           has_pegasus_data_version_ = true;
         } else {
-          msg = "value schema version";
+          msg = "Pegasus data version";
         }
         break;
 

--- a/db/version_edit.cc
+++ b/db/version_edit.cc
@@ -68,7 +68,7 @@ void VersionEdit::Clear() {
   last_flush_decree_ = 0;
   next_file_number_ = 0;
   max_column_family_ = 0;
-  value_schema_version_ = 0;
+  pegasus_data_version_ = 0;
   last_manual_compact_finish_time_ = 0;
   has_comparator_ = false;
   has_log_number_ = false;
@@ -77,7 +77,7 @@ void VersionEdit::Clear() {
   has_last_sequence_ = false;
   has_last_flush_seq_decree_ = false;
   has_max_column_family_ = false;
-  has_value_schema_version_ = false;
+  has_pegasus_data_version_ = false;
   has_last_manual_compact_finish_time_ = false;
   deleted_files_.clear();
   new_files_.clear();
@@ -112,9 +112,9 @@ bool VersionEdit::EncodeTo(std::string* dst) const {
   if (has_max_column_family_) {
     PutVarint32Varint32(dst, kMaxColumnFamily, max_column_family_);
   }
-  if (has_value_schema_version_) {
+  if (has_pegasus_data_version_) {
     PutVarint32(dst, kValueSchemaVersion);
-    PutVarint32(dst, value_schema_version_);
+    PutVarint32(dst, pegasus_data_version_);
   }
   if (has_last_manual_compact_finish_time_) {
     PutVarint32(dst, kLastManualCompactFinishTime);
@@ -363,8 +363,8 @@ Status VersionEdit::DecodeFrom(const Slice& src) {
         break;
 
       case kValueSchemaVersion:
-        if (GetVarint32(&input, &value_schema_version_)) {
-          has_value_schema_version_ = true;
+        if (GetVarint32(&input, &pegasus_data_version_)) {
+          has_pegasus_data_version_ = true;
         } else {
           msg = "value schema version";
         }
@@ -574,9 +574,9 @@ std::string VersionEdit::DebugString(bool hex_key) const {
     r.append("\n  MaxColumnFamily: ");
     AppendNumberTo(&r, max_column_family_);
   }
-  if (has_value_schema_version_) {
+  if (has_pegasus_data_version_) {
     r.append("\n  ValueSchemaVersion: ");
-    AppendNumberTo(&r, value_schema_version_);
+    AppendNumberTo(&r, pegasus_data_version_);
   }
   if (has_last_manual_compact_finish_time_) {
     r.append("\n  LastManualCompactFinishTime: ");
@@ -655,8 +655,8 @@ std::string VersionEdit::DebugJSON(int edit_num, bool hex_key) const {
   if (has_max_column_family_) {
     jw << "MaxColumnFamily" << max_column_family_;
   }
-  if (has_value_schema_version_) {
-    jw << "ValueSchemaVersion" << value_schema_version_;
+  if (has_pegasus_data_version_) {
+    jw << "PegasusDataVersion" << pegasus_data_version_;
   }
   if (has_last_manual_compact_finish_time_) {
     jw << "LastManualCompactFinishTime" << last_manual_compact_finish_time_;

--- a/db/version_edit.h
+++ b/db/version_edit.h
@@ -199,9 +199,9 @@ class VersionEdit {
     max_column_family_ = max_column_family;
   }
 
-  void SetValueSchemaVersion(uint32_t value_schema_version) {
-    has_value_schema_version_ = true;
-    value_schema_version_ = value_schema_version;
+  void SetPegasusDataVersion(uint32_t pegasus_data_version) {
+    has_pegasus_data_version_ = true;
+    pegasus_data_version_ = pegasus_data_version;
   }
 
   void SetLastManualCompactFinishTime(uint64_t ms) {
@@ -217,11 +217,7 @@ class VersionEdit {
     return last_sequence_;
   }
 
-  bool HasLastFlushSeqDecree() const {
-    return has_last_flush_seq_decree_;
-  }
-
-  void GetLastFlushSeqDecree(SequenceNumber* sequence, uint64_t* decree) {
+  void GetLastFlushSeqDecree(SequenceNumber* sequence, uint64_t* decree) const {
     *sequence = last_flush_sequence_;
     *decree = last_flush_decree_;
   }
@@ -320,7 +316,7 @@ class VersionEdit {
   uint64_t prev_log_number_;
   uint64_t next_file_number_;
   uint32_t max_column_family_;
-  uint32_t value_schema_version_;
+  uint32_t pegasus_data_version_;
   uint64_t last_manual_compact_finish_time_;
   SequenceNumber last_sequence_;
   // Used to mark the last sequence/decree of flushed memtables.
@@ -334,7 +330,7 @@ class VersionEdit {
   bool has_last_sequence_;
   bool has_last_flush_seq_decree_;
   bool has_max_column_family_;
-  bool has_value_schema_version_;
+  bool has_pegasus_data_version_;
   bool has_last_manual_compact_finish_time_;
 
   DeletedFileSet deleted_files_;

--- a/db/version_set.cc
+++ b/db/version_set.cc
@@ -2377,6 +2377,8 @@ std::string Version::DebugString(bool hex, bool print_stats) const {
       AppendNumberTo(&r, files[i]->fd.GetNumber());
       r.push_back(':');
       AppendNumberTo(&r, files[i]->fd.GetFileSize());
+      // TODO(laiyingchun): Pegasus added code to dump seqnos, maybe we should
+      // commit these code to facebook/rocksdb later.
       r.append("[");
       AppendNumberTo(&r, files[i]->smallest_seqno);
       r.append(" .. ");

--- a/db/version_set.cc
+++ b/db/version_set.cc
@@ -2596,7 +2596,7 @@ Status VersionSet::LogAndApply(ColumnFamilyData* column_family_data,
       w.edit_list.front()->SetMaxColumnFamily(
           column_family_set_->GetMaxColumnFamily());
     }
-    // also we need to persist value schema version
+    // also we need to persist Pegasus data version
     w.edit_list.front()->SetPegasusDataVersion(
         column_family_set_->GetPegasusDataVersion());
   }
@@ -3085,9 +3085,6 @@ Status VersionSet::Recover(
     } else if (!have_pegasus_data_version) {
       if (db_options_->pegasus_data) {
         s = Status::Corruption("no pegasus-data-version entry in descriptor");
-      } else {
-        ROCKS_LOG_WARN(db_options_->info_log,
-                       "no pegasus-data-version entry in descriptor");
       }
     } else if (!have_last_manual_compact_finish_time) {
       ROCKS_LOG_WARN(db_options_->info_log,

--- a/db/version_set.h
+++ b/db/version_set.h
@@ -617,12 +617,12 @@ class Version {
 
   void GetColumnFamilyMetaData(ColumnFamilyMetaData* cf_meta);
 
-  void GetLastFlushSeqDecree(SequenceNumber* sequence, uint64_t* decree) {
+  void GetLastFlushSeqDecree(SequenceNumber* sequence, uint64_t* decree) const {
     *sequence = last_flush_sequence_;
     *decree = last_flush_decree_;
   }
 
-  void UpdateLastFlushSeqDecree(SequenceNumber sequence, uint64_t decree) {
+  void UpdateLastFlushSeqDecreeIfNeeded(SequenceNumber sequence, uint64_t decree) {
     if (sequence > last_flush_sequence_) {
       assert(decree >= last_flush_decree_);
       last_flush_sequence_ = sequence;
@@ -795,7 +795,9 @@ class VersionSet {
   }
 
   // Return the last flush sequence number of default column family.
-  uint64_t LastFlushSequence() {
+  uint64_t LastFlushSequence() const {
+    assert(db_options_->pegasus_data);
+    assert(column_family_set_->NumberOfColumnFamilies() == 1u);
     SequenceNumber seq;
     uint64_t d;
     column_family_set_->GetDefault()->current()->GetLastFlushSeqDecree(&seq, &d);

--- a/db/write_batch.cc
+++ b/db/write_batch.cc
@@ -884,7 +884,6 @@ class MemTableInserter : public WriteBatch::Handler {
 
   SequenceNumber sequence_;
   ColumnFamilyMemTables* const cf_mems_;
-  uint64_t decree_;
   FlushScheduler* const flush_scheduler_;
   const bool ignore_missing_column_families_;
   const uint64_t recovering_log_number_;
@@ -911,6 +910,8 @@ class MemTableInserter : public WriteBatch::Handler {
   bool seq_per_batch_;
   // Whether the memtable write will be done only after the commit
   bool write_after_commit_;
+  uint64_t decree_;
+  bool pegasus_data_;
 
   MemPostInfoMap& GetPostMap() {
     assert(concurrent_memtable_writes_);
@@ -928,11 +929,12 @@ class MemTableInserter : public WriteBatch::Handler {
                    bool ignore_missing_column_families,
                    uint64_t recovering_log_number, DB* db,
                    bool concurrent_memtable_writes,
-                   uint64_t decree,
-                   bool* has_valid_writes = nullptr, bool seq_per_batch = false)
+                   bool* has_valid_writes = nullptr,
+                   bool seq_per_batch = false,
+                   uint64_t decree = 0,
+                   bool pegasus_data = false)
       : sequence_(_sequence),
         cf_mems_(cf_mems),
-        decree_(decree),
         flush_scheduler_(flush_scheduler),
         ignore_missing_column_families_(ignore_missing_column_families),
         recovering_log_number_(recovering_log_number),
@@ -946,7 +948,9 @@ class MemTableInserter : public WriteBatch::Handler {
         // Write after commit currently uses one seq per key (instead of per
         // batch). So seq_per_batch being false indicates write_after_commit
         // approach.
-        write_after_commit_(!seq_per_batch) {
+        write_after_commit_(!seq_per_batch),
+        decree_(decree),
+        pegasus_data_(pegasus_data) {
     assert(cf_mems_);
   }
 
@@ -1086,10 +1090,12 @@ class MemTableInserter : public WriteBatch::Handler {
         }
       }
     }
-    // Since all Puts are logged in trasaction logs (if enabled), always bump
+    // Since all Puts are logged in transaction logs (if enabled), always bump
     // sequence number. Even if the update eventually fails and does not result
     // in memtable add/update.
-    mem->UpdateLastSeqDecree(sequence_, decree_);
+    if (pegasus_data_) {
+      mem->UpdateLastSeqDecree(sequence_, decree_);
+    }
     MaybeAdvanceSeq();
     CheckMemtableFull();
     return Status::OK();
@@ -1105,7 +1111,9 @@ class MemTableInserter : public WriteBatch::Handler {
     MemTable* mem = cf_mems_->GetMemTable();
     mem->Add(sequence_, delete_type, key, value, concurrent_memtable_writes_,
              get_post_process_info(mem));
-    mem->UpdateLastSeqDecree(sequence_, decree_);
+    if (pegasus_data_) {
+      mem->UpdateLastSeqDecree(sequence_, decree_);
+    }
     MaybeAdvanceSeq();
     CheckMemtableFull();
     return Status::OK();
@@ -1263,8 +1271,9 @@ class MemTableInserter : public WriteBatch::Handler {
       // Add merge operator to memtable
       mem->Add(sequence_, kTypeMerge, key, value);
     }
-
-    mem->UpdateLastSeqDecree(sequence_, decree_);
+    if (pegasus_data_) {
+      mem->UpdateLastSeqDecree(sequence_, decree_);
+    }
     MaybeAdvanceSeq();
     CheckMemtableFull();
     return Status::OK();
@@ -1428,11 +1437,12 @@ Status WriteBatchInternal::InsertInto(
     ColumnFamilyMemTables* memtables, FlushScheduler* flush_scheduler,
     bool ignore_missing_column_families, uint64_t recovery_log_number, DB* db,
     bool concurrent_memtable_writes, bool seq_per_batch,
-    uint64_t decree) {
+    uint64_t decree, bool pegasus_data) {
   MemTableInserter inserter(sequence, memtables, flush_scheduler,
                             ignore_missing_column_families, recovery_log_number,
-                            db, concurrent_memtable_writes, decree,
-                            nullptr /*has_valid_writes*/, seq_per_batch);
+                            db, concurrent_memtable_writes,
+                            nullptr /*has_valid_writes*/, seq_per_batch,
+                            decree, pegasus_data);
   for (auto w : write_group) {
     if (!w->ShouldWriteToMemtable()) {
       w->sequence = inserter.sequence();
@@ -1454,12 +1464,11 @@ Status WriteBatchInternal::InsertInto(
     WriteThread::Writer* writer, SequenceNumber sequence,
     ColumnFamilyMemTables* memtables, FlushScheduler* flush_scheduler,
     bool ignore_missing_column_families, uint64_t log_number, DB* db,
-    bool concurrent_memtable_writes, bool seq_per_batch,
-    uint64_t decree) {
+    bool concurrent_memtable_writes, bool seq_per_batch) {
   assert(writer->ShouldWriteToMemtable());
   MemTableInserter inserter(sequence, memtables, flush_scheduler,
                             ignore_missing_column_families, log_number, db,
-                            concurrent_memtable_writes, decree,
+                            concurrent_memtable_writes,
                             nullptr /*has_valid_writes*/, seq_per_batch);
   SetSequence(writer->batch, sequence);
   inserter.set_log_number_ref(writer->log_ref);
@@ -1474,11 +1483,10 @@ Status WriteBatchInternal::InsertInto(
     const WriteBatch* batch, ColumnFamilyMemTables* memtables,
     FlushScheduler* flush_scheduler, bool ignore_missing_column_families,
     uint64_t log_number, DB* db, bool concurrent_memtable_writes,
-    SequenceNumber* next_seq, bool* has_valid_writes, bool seq_per_batch,
-    uint64_t decree) {
+    SequenceNumber* next_seq, bool* has_valid_writes, bool seq_per_batch) {
   MemTableInserter inserter(Sequence(batch), memtables, flush_scheduler,
                             ignore_missing_column_families, log_number, db,
-                            concurrent_memtable_writes, decree, has_valid_writes,
+                            concurrent_memtable_writes, has_valid_writes,
                             seq_per_batch);
   Status s = batch->Iterate(&inserter);
   if (next_seq != nullptr) {

--- a/db/write_batch.cc
+++ b/db/write_batch.cc
@@ -1090,7 +1090,7 @@ class MemTableInserter : public WriteBatch::Handler {
         }
       }
     }
-    // Since all Puts are logged in transaction logs (if enabled), always bump
+    // Since all Puts are logged in trasaction logs (if enabled), always bump
     // sequence number. Even if the update eventually fails and does not result
     // in memtable add/update.
     if (pegasus_data_) {

--- a/db/write_batch_internal.h
+++ b/db/write_batch_internal.h
@@ -162,7 +162,8 @@ class WriteBatchInternal {
                            uint64_t log_number = 0, DB* db = nullptr,
                            bool concurrent_memtable_writes = false,
                            bool seq_per_batch = false,
-                           uint64_t decree = 0);
+                           uint64_t decree = 0,
+                           bool pegasus_data = false);
 
   // Convenience form of InsertInto when you have only one batch
   // next_seq returns the seq after last sequence number used in MemTable insert
@@ -174,8 +175,7 @@ class WriteBatchInternal {
                            bool concurrent_memtable_writes = false,
                            SequenceNumber* next_seq = nullptr,
                            bool* has_valid_writes = nullptr,
-                           bool seq_per_batch = false,
-                           uint64_t decree = 0);
+                           bool seq_per_batch = false);
 
   static Status InsertInto(WriteThread::Writer* writer, SequenceNumber sequence,
                            ColumnFamilyMemTables* memtables,
@@ -183,8 +183,7 @@ class WriteBatchInternal {
                            bool ignore_missing_column_families = false,
                            uint64_t log_number = 0, DB* db = nullptr,
                            bool concurrent_memtable_writes = false,
-                           bool seq_per_batch = false,
-                           uint64_t decree = 0);
+                           bool seq_per_batch = false);
 
   static Status Append(WriteBatch* dst, const WriteBatch* src,
                        const bool WAL_only = false);

--- a/db/write_callback_test.cc
+++ b/db/write_callback_test.cc
@@ -24,11 +24,11 @@ using std::string;
 
 namespace rocksdb {
 
-class DISABLED_WriteCallbackTest : public testing::Test {
+class WriteCallbackTest : public testing::Test {
  public:
   string dbname;
 
-  DISABLED_WriteCallbackTest() {
+  WriteCallbackTest() {
     dbname = test::TmpDir() + "/write_callback_testdb";
   }
 };
@@ -86,7 +86,7 @@ class MockWriteCallback : public WriteCallback {
   bool AllowWriteBatching() override { return allow_batching_; }
 };
 
-TEST_F(DISABLED_WriteCallbackTest, WriteWithCallbackTest) {
+TEST_F(WriteCallbackTest, WriteWithCallbackTest) {
   struct WriteOP {
     WriteOP(bool should_fail = false) { callback_.should_fail_ = should_fail; }
 
@@ -322,7 +322,7 @@ TEST_F(DISABLED_WriteCallbackTest, WriteWithCallbackTest) {
 }
 }
 
-TEST_F(DISABLED_WriteCallbackTest, WriteCallBackTest) {
+TEST_F(WriteCallbackTest, WriteCallBackTest) {
   Options options;
   WriteOptions write_options;
   ReadOptions read_options;

--- a/include/rocksdb/db.h
+++ b/include/rocksdb/db.h
@@ -884,12 +884,12 @@ class DB {
   virtual bool SetPreserveDeletesSequenceNumber(SequenceNumber seqnum) = 0;
 
   // The last flushed decree.
-  virtual uint64_t GetLastFlushedDecree() { return 0; }
+  virtual uint64_t GetLastFlushedDecree() const { return 0; }
 
-  // The value schame version.
-  virtual uint32_t GetValueSchemaVersion() { return 0; }
+  // The Pegasus data version.
+  virtual uint32_t GetPegasusDataVersion() const { return 0; }
 
-  virtual uint64_t GetLastManualCompactFinishTime() { return 0; }
+  virtual uint64_t GetLastManualCompactFinishTime() const { return 0; }
 
 #ifndef ROCKSDB_LITE
 
@@ -933,7 +933,7 @@ class DB {
   virtual Status GetLiveFilesQuick(std::vector<std::string>& ret,
                                    uint64_t* manifest_file_size,
                                    SequenceNumber* last_sequence,
-                                   uint64_t* last_decree) { return Status::NotSupported(); }
+                                   uint64_t* last_decree) const { return Status::NotSupported(); }
 
   // Retrieve the sorted list of all wal files with earliest file first
   virtual Status GetSortedWalFiles(VectorLogPtr& files) = 0;

--- a/include/rocksdb/options.h
+++ b/include/rocksdb/options.h
@@ -922,9 +922,13 @@ struct DBOptions {
   // projects.
   bool seq_per_batch = false;
 
-  // Default value schema version.
+  // Whether the data is for Pegasus.
+  // Default: false
+  bool pegasus_data = false;
+
+  // Pegasus data version.
   // Default: 0
-  uint32_t default_value_schema_version = 0;
+  uint32_t pegasus_data_version = 0;
 };
 
 // Options to control the behavior of a database (passed to DB::Open)
@@ -1153,14 +1157,6 @@ struct WriteOptions {
   // Default: false
   bool low_pri;
 
-  // Sequence number is usually controlled by the db itself as 1,2,3, ...
-  // however, in cases where the upper frameworks (e.g., replication), the sequence
-  // number is given and the underlying db should use this given sequence number directly
-  // instead of generating one by itself.
-  //
-  // Default: 0 (rocksdb should generate the number by itself in this case)
-  SequenceNumber given_sequence_number;
-
   // Decree is an value affiliated to the write.
   uint64_t given_decree;
 
@@ -1170,7 +1166,6 @@ struct WriteOptions {
         ignore_missing_column_families(false),
         no_slowdown(false),
         low_pri(false),
-        given_sequence_number(0),
         given_decree(0) {}
 };
 

--- a/include/rocksdb/slice.h
+++ b/include/rocksdb/slice.h
@@ -54,7 +54,6 @@ class Slice {
 
   // Return the length (in bytes) of the referenced data
   size_t size() const { return size_; }
-  size_t length() const { return size_; }
 
   // Return true iff the length of the referenced data is zero
   bool empty() const { return size_ == 0; }

--- a/include/rocksdb/status.h
+++ b/include/rocksdb/status.h
@@ -58,7 +58,7 @@ class Status {
     kAborted = 10,
     kBusy = 11,
     kExpired = 12,
-    kTryAgain = 13,
+    kTryAgain = 13
   };
 
   Code code() const { return code_; }

--- a/include/rocksdb/utilities/checkpoint.h
+++ b/include/rocksdb/utilities/checkpoint.h
@@ -10,7 +10,6 @@
 
 #include <string>
 #include "rocksdb/status.h"
-#include "rocksdb/types.h"
 
 namespace rocksdb {
 

--- a/include/rocksdb/write_batch.h
+++ b/include/rocksdb/write_batch.h
@@ -356,9 +356,6 @@ class WriteBatch : public WriteBatchBase {
  protected:
   std::string rep_;  // See comment in write_batch.cc for the format of rep_
 
-  bool use_shared_sequence_number_; // when seq is given and shared by multiple write ops,
-                                    // see more comments for WriteOptions
-
   // Intentionally copyable
 };
 

--- a/options/db_options.cc
+++ b/options/db_options.cc
@@ -88,7 +88,8 @@ ImmutableDBOptions::ImmutableDBOptions(const DBOptions& options)
       concurrent_prepare(options.concurrent_prepare),
       manual_wal_flush(options.manual_wal_flush),
       seq_per_batch(options.seq_per_batch),
-      default_value_schema_version(options.default_value_schema_version) {
+      pegasus_data(options.pegasus_data),
+      pegasus_data_version(options.pegasus_data_version) {
 }
 
 void ImmutableDBOptions::Dump(Logger* log) const {
@@ -223,8 +224,9 @@ void ImmutableDBOptions::Dump(Logger* log) const {
   ROCKS_LOG_HEADER(log, "            Options.manual_wal_flush: %d",
                    manual_wal_flush);
   ROCKS_LOG_HEADER(log, "            Options.seq_per_batch: %d", seq_per_batch);
-  ROCKS_LOG_HEADER(log, "            Options.default_value_schema_version: %d",
-                   default_value_schema_version);
+  ROCKS_LOG_HEADER(log, "            Options.pegasus_data: %d", pegasus_data);
+  ROCKS_LOG_HEADER(log, "            Options.pegasus_data_version: %d",
+                   pegasus_data_version);
 }
 
 MutableDBOptions::MutableDBOptions()

--- a/options/db_options.h
+++ b/options/db_options.h
@@ -80,7 +80,8 @@ struct ImmutableDBOptions {
   bool concurrent_prepare;
   bool manual_wal_flush;
   bool seq_per_batch;
-  uint32_t default_value_schema_version;
+  bool pegasus_data;
+  uint32_t pegasus_data_version;
 };
 
 struct MutableDBOptions {

--- a/options/options_helper.cc
+++ b/options/options_helper.cc
@@ -123,6 +123,10 @@ DBOptions BuildDBOptions(const ImmutableDBOptions& immutable_db_options,
       immutable_db_options.allow_ingest_behind;
   options.preserve_deletes =
       immutable_db_options.preserve_deletes;
+  options.pegasus_data =
+      immutable_db_options.pegasus_data;
+  options.pegasus_data_version =
+      immutable_db_options.pegasus_data_version;
 
   return options;
 }

--- a/options/options_helper.h
+++ b/options/options_helper.h
@@ -372,10 +372,14 @@ static std::unordered_map<std::string, OptionTypeInfo> db_options_type_info = {
      {offsetof(struct DBOptions, seq_per_batch), OptionType::kBoolean,
       OptionVerificationType::kNormal, false,
       offsetof(struct ImmutableDBOptions, seq_per_batch)}},
-    {"default_value_schema_version",
-     {offsetof(struct DBOptions, default_value_schema_version), OptionType::kUInt32T,
+    {"pegasus_data",
+     {offsetof(struct DBOptions, pegasus_data), OptionType::kBoolean,
       OptionVerificationType::kNormal, false,
-      offsetof(struct ImmutableDBOptions, default_value_schema_version)}}};
+      offsetof(struct ImmutableDBOptions, pegasus_data)}},
+    {"pegasus_data_version",
+     {offsetof(struct DBOptions, pegasus_data_version), OptionType::kUInt32T,
+      OptionVerificationType::kNormal, false,
+      offsetof(struct ImmutableDBOptions, pegasus_data_version)}}};
 
 // offset_of is used to get the offset of a class data member
 // ex: offset_of(&ColumnFamilyOptions::num_levels)

--- a/options/options_settable_test.cc
+++ b/options/options_settable_test.cc
@@ -286,7 +286,8 @@ TEST_F(OptionsSettableTest, DBOptionsAllFieldsSettable) {
                              "concurrent_prepare=false;"
                              "manual_wal_flush=false;"
                              "seq_per_batch=false;"
-                             "default_value_schema_version=0;",
+                             "pegasus_data=false;"
+                             "pegasus_data_version=0;",
                              new_options));
 
   ASSERT_EQ(unset_bytes_base, NumUnsetBytes(new_options_ptr, sizeof(DBOptions),

--- a/port/win/env_win.h
+++ b/port/win/env_win.h
@@ -132,10 +132,6 @@ public:
   virtual Status GetFileModificationTime(const std::string& fname,
     uint64_t* file_mtime);
 
-  static BOOL IsDots(const char* str);
-
-  static BOOL DeleteDirectory(const char* sPath);
-
   virtual Status RenameFile(const std::string& src,
     const std::string& target);
 
@@ -245,10 +241,6 @@ public:
 
   Status GetFileModificationTime(const std::string& fname,
     uint64_t* file_mtime) override;
-
-  BOOL IsDots(const char* str);
-
-  BOOL DeleteDirectory(const char* sPath);
 
   Status RenameFile(const std::string& src,
     const std::string& target) override;

--- a/table/table_test.cc
+++ b/table/table_test.cc
@@ -2488,9 +2488,9 @@ static void DoCompressionTest(CompressionType comp) {
   ASSERT_TRUE(Between(c.ApproximateOffsetOf("abc"),       0,      0));
   ASSERT_TRUE(Between(c.ApproximateOffsetOf("k01"),       0,      0));
   ASSERT_TRUE(Between(c.ApproximateOffsetOf("k02"),       0,      0));
-  ASSERT_TRUE(Between(c.ApproximateOffsetOf("k03"),    2000,   3000));
-  ASSERT_TRUE(Between(c.ApproximateOffsetOf("k04"),    2000,   3000));
-  ASSERT_TRUE(Between(c.ApproximateOffsetOf("xyz"),    4000,   6100));
+  ASSERT_TRUE(Between(c.ApproximateOffsetOf("k03"),    2000,   3500));
+  ASSERT_TRUE(Between(c.ApproximateOffsetOf("k04"),    2000,   3500));
+  ASSERT_TRUE(Between(c.ApproximateOffsetOf("xyz"),    4000,   6500));
   c.ResetTableReader();
 }
 

--- a/tools/ldb_cmd.cc
+++ b/tools/ldb_cmd.cc
@@ -84,7 +84,7 @@ namespace {
 void DumpWalFile(std::string wal_file, bool print_header, bool print_values,
                  LDBCommandExecuteResult* exec_state);
 
-void DumpSstFile(std::string filename, bool output_hex, bool show_properties);
+void DumpSstFile(std::string filename, bool output_hex, bool show_properties, bool pegasus_data);
 };
 
 LDBCommand* LDBCommand::InitFromCmdLineArgs(
@@ -1283,6 +1283,7 @@ const std::string DBDumperCommand::ARG_COUNT_ONLY = "count_only";
 const std::string DBDumperCommand::ARG_COUNT_DELIM = "count_delim";
 const std::string DBDumperCommand::ARG_STATS = "stats";
 const std::string DBDumperCommand::ARG_TTL_BUCKET = "bucket";
+const std::string DBDumperCommand::ARG_PEGASUS_DATA = "pegasus_data";
 
 DBDumperCommand::DBDumperCommand(
     const std::vector<std::string>& params,
@@ -1293,13 +1294,14 @@ DBDumperCommand::DBDumperCommand(
                      {ARG_TTL, ARG_HEX, ARG_KEY_HEX, ARG_VALUE_HEX, ARG_FROM,
                       ARG_TO, ARG_MAX_KEYS, ARG_COUNT_ONLY, ARG_COUNT_DELIM,
                       ARG_STATS, ARG_TTL_START, ARG_TTL_END, ARG_TTL_BUCKET,
-                      ARG_TIMESTAMP, ARG_PATH})),
+                      ARG_TIMESTAMP, ARG_PATH, ARG_PEGASUS_DATA})),
       null_from_(true),
       null_to_(true),
       max_keys_(-1),
       count_only_(false),
       count_delim_(false),
-      print_stats_(false) {
+      print_stats_(false),
+      pegasus_data_(false) {
   std::map<std::string, std::string>::const_iterator itr =
       options.find(ARG_FROM);
   if (itr != options.end()) {
@@ -1340,6 +1342,7 @@ DBDumperCommand::DBDumperCommand(
 
   print_stats_ = IsFlagPresent(flags, ARG_STATS);
   count_only_ = IsFlagPresent(flags, ARG_COUNT_ONLY);
+  pegasus_data_ = IsFlagPresent(flags, ARG_PEGASUS_DATA);
 
   if (is_key_hex_) {
     if (!null_from_) {
@@ -1373,6 +1376,7 @@ void DBDumperCommand::Help(std::string& ret) {
   ret.append(" [--" + ARG_TTL_START + "=<N>:- is inclusive]");
   ret.append(" [--" + ARG_TTL_END + "=<N>:- is exclusive]");
   ret.append(" [--" + ARG_PATH + "=<path_to_a_file>]");
+  ret.append(" [--" + ARG_PEGASUS_DATA + "]");
   ret.append("\n");
 }
 
@@ -1408,7 +1412,7 @@ void DBDumperCommand::DoCommand() {
                     &exec_state_);
         break;
       case kTableFile:
-        DumpSstFile(path_, is_key_hex_, /* show_properties */ true);
+        DumpSstFile(path_, is_key_hex_, /* show_properties */ true, pegasus_data_);
         break;
       case kDescriptorFile:
         DumpManifestFile(path_, /* verbose_ */ false, is_key_hex_,
@@ -1542,6 +1546,7 @@ void DBDumperCommand::DoDumpCommand() {
       if (is_db_ttl_ && timestamp_) {
         fprintf(stdout, "%s ", ReadableTime(rawtime).c_str());
       }
+      // TODO(laiyingchun): data decoding depends on whether it is pegasus data.
       std::string str =
           PrintKeyValue(iter->key().ToString(), iter->value().ToString(),
                         is_key_hex_, is_value_hex_);
@@ -2532,6 +2537,7 @@ void DBQuerierCommand::DoCommand() {
 
     const std::string& cmd = tokens[0];
 
+    // TODO(laiyingchun): data encoding/decoding depends on whether it is pegasus data.
     if (cmd == HELP_CMD) {
       fprintf(stdout,
               "get <key>\n"
@@ -2796,7 +2802,7 @@ void RestoreCommand::DoCommand() {
 
 namespace {
 
-void DumpSstFile(std::string filename, bool output_hex, bool show_properties) {
+void DumpSstFile(std::string filename, bool output_hex, bool show_properties, bool pegasus_data) {
   std::string from_key;
   std::string to_key;
   if (filename.length() <= 4 ||
@@ -2805,7 +2811,9 @@ void DumpSstFile(std::string filename, bool output_hex, bool show_properties) {
     return;
   }
   // no verification
-  rocksdb::SstFileReader reader(filename, false, output_hex);
+  Options options;
+  options.pegasus_data = pegasus_data;
+  rocksdb::SstFileReader reader(filename, false, output_hex, options);
   Status st = reader.ReadSequential(true, std::numeric_limits<uint64_t>::max(), false,  // has_from
                                     from_key, false,  // has_to
                                     to_key);
@@ -2885,7 +2893,7 @@ void DBFileDumperCommand::DoCommand() {
     std::string filename = fileMetadata.db_path + fileMetadata.name;
     std::cout << filename << " level:" << fileMetadata.level << std::endl;
     std::cout << "------------------------------" << std::endl;
-    DumpSstFile(filename, false, true);
+    DumpSstFile(filename, false, true, db_->GetDBOptions().pegasus_data);
     std::cout << std::endl;
   }
   std::cout << std::endl;

--- a/tools/ldb_cmd.cc
+++ b/tools/ldb_cmd.cc
@@ -1546,7 +1546,7 @@ void DBDumperCommand::DoDumpCommand() {
       if (is_db_ttl_ && timestamp_) {
         fprintf(stdout, "%s ", ReadableTime(rawtime).c_str());
       }
-      // TODO(laiyingchun): data decoding depends on whether it is pegasus data.
+      // TODO(laiyingchun): data decoding depends on whether it is Pegasus data.
       std::string str =
           PrintKeyValue(iter->key().ToString(), iter->value().ToString(),
                         is_key_hex_, is_value_hex_);
@@ -2537,7 +2537,7 @@ void DBQuerierCommand::DoCommand() {
 
     const std::string& cmd = tokens[0];
 
-    // TODO(laiyingchun): data encoding/decoding depends on whether it is pegasus data.
+    // TODO(laiyingchun): data encoding/decoding depends on whether it is Pegasus data.
     if (cmd == HELP_CMD) {
       fprintf(stdout,
               "get <key>\n"

--- a/tools/ldb_cmd_impl.h
+++ b/tools/ldb_cmd_impl.h
@@ -84,12 +84,14 @@ class DBDumperCommand : public LDBCommand {
   bool count_only_;
   bool count_delim_;
   bool print_stats_;
+  bool pegasus_data_;
   std::string path_;
 
   static const std::string ARG_COUNT_ONLY;
   static const std::string ARG_COUNT_DELIM;
   static const std::string ARG_STATS;
   static const std::string ARG_TTL_BUCKET;
+  static const std::string ARG_PEGASUS_DATA;
 };
 
 class InternalDumpCommand : public LDBCommand {

--- a/tools/sst_dump_tool.cc
+++ b/tools/sst_dump_tool.cc
@@ -45,7 +45,8 @@ namespace rocksdb {
 
 SstFileReader::SstFileReader(const std::string& file_path,
                              bool verify_checksum,
-                             bool output_hex, Options options)
+                             bool output_hex,
+                             Options options)
     :file_name_(file_path), read_num_(0), verify_checksum_(verify_checksum),
     output_hex_(output_hex), options_(std::move(options)), ioptions_(options_),
     internal_comparator_(BytewiseComparator()) {

--- a/tools/sst_dump_tool_imp.h
+++ b/tools/sst_dump_tool_imp.h
@@ -18,7 +18,7 @@ namespace rocksdb {
 class SstFileReader {
  public:
   explicit SstFileReader(const std::string& file_name, bool verify_checksum,
-                         bool output_hex);
+                         bool output_hex, Options options);
 
   Status ReadSequential(bool print_kv, uint64_t read_num, bool has_from,
                         const std::string& from_key, bool has_to,
@@ -62,6 +62,7 @@ class SstFileReader {
   std::string file_name_;
   uint64_t read_num_;
   bool verify_checksum_;
+  bool output_hex_;
   EnvOptions soptions_;
 
   // options_ and internal_comparator_ will also be used in

--- a/util/slice.cc
+++ b/util/slice.cc
@@ -130,11 +130,11 @@ int fromHex(char c) {
 }
 
 Slice::Slice(const SliceParts& parts, std::string* buf) {
-  size_t len = 0;
+  size_t length = 0;
   for (int i = 0; i < parts.num_parts; ++i) {
-    len += parts.parts[i].size();
+    length += parts.parts[i].size();
   }
-  buf->reserve(len);
+  buf->reserve(length);
 
   for (int i = 0; i < parts.num_parts; ++i) {
     buf->append(parts.parts[i].data(), parts.parts[i].size());

--- a/util/sync_point.cc
+++ b/util/sync_point.cc
@@ -8,7 +8,6 @@
 #include <thread>
 #include "port/port.h"
 #include "util/random.h"
-#include <mutex>
 
 int rocksdb_kill_odds = 0;
 std::vector<std::string> rocksdb_kill_prefix_blacklist;
@@ -38,13 +37,8 @@ void TestKillRandom(std::string kill_point, int odds,
 }
 
 SyncPoint* SyncPoint::GetInstance() {
-  static std::once_flag flag;
-  static SyncPoint* psync_point = nullptr;
-  std::call_once(flag, [&]()
-  {
-      psync_point = new SyncPoint();
-  });
-  return psync_point;
+  static SyncPoint sync_point;
+  return &sync_point;
 }
 
 void SyncPoint::LoadDependency(const std::vector<SyncPointPair>& dependencies) {

--- a/util/testutil.cc
+++ b/util/testutil.cc
@@ -261,6 +261,7 @@ void RandomInitDBOptions(DBOptions* db_opt, Random* rnd) {
   db_opt->recycle_log_file_num = rnd->Uniform(2);
   db_opt->avoid_flush_during_recovery = rnd->Uniform(2);
   db_opt->avoid_flush_during_shutdown = rnd->Uniform(2);
+  db_opt->pegasus_data = rnd->Uniform(2);
 
   // int options
   db_opt->max_background_compactions = rnd->Uniform(100);
@@ -282,6 +283,7 @@ void RandomInitDBOptions(DBOptions* db_opt, Random* rnd) {
 
   // uint32_t options
   db_opt->max_subcompactions = rnd->Uniform(100000);
+  db_opt->pegasus_data_version = rnd->Uniform(100000);
 
   // uint64_t options
   static const uint64_t uint_max = static_cast<uint64_t>(UINT_MAX);

--- a/util/thread_local.cc
+++ b/util/thread_local.cc
@@ -11,7 +11,6 @@
 #include "util/mutexlock.h"
 #include "port/likely.h"
 #include <stdlib.h>
-#include <mutex>
 
 namespace rocksdb {
 
@@ -266,16 +265,8 @@ ThreadLocalPtr::StaticMeta* ThreadLocalPtr::Instance() {
   // destruction order even when the main thread dies before any child threads.
   // However, thread_local is not supported in all compilers that accept -std=c++11
   // (e.g., eg Mac with XCode < 8. XCode 8+ supports thread_local).
-//  static ThreadLocalPtr::StaticMeta* inst = new ThreadLocalPtr::StaticMeta();
-//  return inst;
-
-  static std::once_flag flag;
-  static ThreadLocalPtr::StaticMeta* pinst = nullptr;
-  std::call_once(flag, [&]()
-  {
-    pinst = new ThreadLocalPtr::StaticMeta();
-  });
-  return pinst;
+  static ThreadLocalPtr::StaticMeta* inst = new ThreadLocalPtr::StaticMeta();
+  return inst;
 }
 
 port::Mutex* ThreadLocalPtr::StaticMeta::Mutex() { return &Instance()->mutex_; }

--- a/utilities/backupable/backupable_db_test.cc
+++ b/utilities/backupable/backupable_db_test.cc
@@ -472,10 +472,9 @@ static void AssertEmpty(DB* db, int from, int to) {
   }
 }
 
-// pegasus: we dont support backup now
-class DISABLED_BackupableDBTest : public testing::Test {
+class BackupableDBTest : public testing::Test {
  public:
-  DISABLED_BackupableDBTest() {
+  BackupableDBTest() {
     // set up files
     std::string db_chroot = test::TmpDir() + "/backupable_db";
     std::string backup_chroot = test::TmpDir() + "/backupable_db_backup";
@@ -636,7 +635,7 @@ class DISABLED_BackupableDBTest : public testing::Test {
 
  protected:
   unique_ptr<BackupableDBOptions> backupable_options_;
-}; // DISABLED_BackupableDBTest
+}; // BackupableDBTest
 
 void AppendPath(const std::string& path, std::vector<std::string>& v) {
   for (auto& f : v) {
@@ -644,17 +643,17 @@ void AppendPath(const std::string& path, std::vector<std::string>& v) {
   }
 }
 
-class DISABLED_BackupableDBTestWithParam : public DISABLED_BackupableDBTest,
+class BackupableDBTestWithParam : public BackupableDBTest,
                                   public testing::WithParamInterface<bool> {
  public:
-  DISABLED_BackupableDBTestWithParam() {
+  BackupableDBTestWithParam() {
     backupable_options_->share_files_with_checksum = GetParam();
   }
 };
 
 // This test verifies that the verifyBackup method correctly identifies
 // invalid backups
-TEST_P(DISABLED_BackupableDBTestWithParam, VerifyBackup) {
+TEST_P(BackupableDBTestWithParam, VerifyBackup) {
   const int keys_iteration = 5000;
   Random rnd(6);
   Status s;
@@ -686,7 +685,7 @@ TEST_P(DISABLED_BackupableDBTestWithParam, VerifyBackup) {
 }
 
 // open DB, write, close DB, backup, restore, repeat
-TEST_P(DISABLED_BackupableDBTestWithParam, OfflineIntegrationTest) {
+TEST_P(BackupableDBTestWithParam, OfflineIntegrationTest) {
   // has to be a big number, so that it triggers the memtable flush
   const int keys_iteration = 5000;
   const int max_key = keys_iteration * 4 + 10;
@@ -733,7 +732,7 @@ TEST_P(DISABLED_BackupableDBTestWithParam, OfflineIntegrationTest) {
 }
 
 // open DB, write, backup, write, backup, close, restore
-TEST_P(DISABLED_BackupableDBTestWithParam, OnlineIntegrationTest) {
+TEST_P(BackupableDBTestWithParam, OnlineIntegrationTest) {
   // has to be a big number, so that it triggers the memtable flush
   const int keys_iteration = 5000;
   const int max_key = keys_iteration * 4 + 10;
@@ -794,11 +793,11 @@ TEST_P(DISABLED_BackupableDBTestWithParam, OnlineIntegrationTest) {
   CloseBackupEngine();
 }
 
-INSTANTIATE_TEST_CASE_P(DISABLED_BackupableDBTestWithParam, DISABLED_BackupableDBTestWithParam,
+INSTANTIATE_TEST_CASE_P(BackupableDBTestWithParam, BackupableDBTestWithParam,
                         ::testing::Bool());
 
 // this will make sure that backup does not copy the same file twice
-TEST_F(DISABLED_BackupableDBTest, NoDoubleCopy) {
+TEST_F(BackupableDBTest, NoDoubleCopy) {
   OpenDBAndBackupEngine(true, true);
 
   // should write 5 DB files + one meta file
@@ -861,7 +860,7 @@ TEST_F(DISABLED_BackupableDBTest, NoDoubleCopy) {
 //      fine
 // 3. Corrupted checksum value - if the checksum is not a valid uint32_t,
 //      db open should fail, otherwise, it aborts during the restore process.
-TEST_F(DISABLED_BackupableDBTest, CorruptionsTest) {
+TEST_F(BackupableDBTest, CorruptionsTest) {
   const int keys_iteration = 5000;
   Random rnd(6);
   Status s;
@@ -961,7 +960,7 @@ TEST_F(DISABLED_BackupableDBTest, CorruptionsTest) {
   AssertBackupConsistency(2, 0, keys_iteration * 2, keys_iteration * 5);
 }
 
-TEST_F(DISABLED_BackupableDBTest, InterruptCreationTest) {
+TEST_F(BackupableDBTest, InterruptCreationTest) {
   // Interrupt backup creation by failing new writes and failing cleanup of the
   // partial state. Then verify a subsequent backup can still succeed.
   const int keys_iteration = 5000;
@@ -997,7 +996,7 @@ inline std::string OptionsPath(std::string ret, int backupID) {
 // Backup the LATEST options file to
 // "<backup_dir>/private/<backup_id>/OPTIONS<number>"
 
-TEST_F(DISABLED_BackupableDBTest, BackupOptions) {
+TEST_F(BackupableDBTest, BackupOptions) {
   OpenDBAndBackupEngine(true);
   for (int i = 1; i < 5; i++) {
     std::string name;
@@ -1022,7 +1021,7 @@ TEST_F(DISABLED_BackupableDBTest, BackupOptions) {
 
 // This test verifies we don't delete the latest backup when read-only option is
 // set
-TEST_F(DISABLED_BackupableDBTest, NoDeleteWithReadOnly) {
+TEST_F(BackupableDBTest, NoDeleteWithReadOnly) {
   const int keys_iteration = 5000;
   Random rnd(6);
   Status s;
@@ -1055,7 +1054,7 @@ TEST_F(DISABLED_BackupableDBTest, NoDeleteWithReadOnly) {
   delete read_only_backup_engine;
 }
 
-TEST_F(DISABLED_BackupableDBTest, FailOverwritingBackups) {
+TEST_F(BackupableDBTest, FailOverwritingBackups) {
   options_.write_buffer_size = 1024 * 1024 * 1024;  // 1GB
   options_.disable_auto_compactions = true;
 
@@ -1092,7 +1091,7 @@ TEST_F(DISABLED_BackupableDBTest, FailOverwritingBackups) {
   CloseDBAndBackupEngine();
 }
 
-TEST_F(DISABLED_BackupableDBTest, NoShareTableFiles) {
+TEST_F(BackupableDBTest, NoShareTableFiles) {
   const int keys_iteration = 5000;
   OpenDBAndBackupEngine(true, false, false);
   for (int i = 0; i < 5; ++i) {
@@ -1108,7 +1107,7 @@ TEST_F(DISABLED_BackupableDBTest, NoShareTableFiles) {
 }
 
 // Verify that you can backup and restore with share_files_with_checksum on
-TEST_F(DISABLED_BackupableDBTest, ShareTableFilesWithChecksums) {
+TEST_F(BackupableDBTest, ShareTableFilesWithChecksums) {
   const int keys_iteration = 5000;
   OpenDBAndBackupEngineShareWithChecksum(true, false, true, true);
   for (int i = 0; i < 5; ++i) {
@@ -1125,7 +1124,7 @@ TEST_F(DISABLED_BackupableDBTest, ShareTableFilesWithChecksums) {
 
 // Verify that you can backup and restore using share_files_with_checksum set to
 // false and then transition this option to true
-TEST_F(DISABLED_BackupableDBTest, ShareTableFilesWithChecksumsTransition) {
+TEST_F(BackupableDBTest, ShareTableFilesWithChecksumsTransition) {
   const int keys_iteration = 5000;
   // set share_files_with_checksum to false
   OpenDBAndBackupEngineShareWithChecksum(true, false, true, false);
@@ -1154,7 +1153,7 @@ TEST_F(DISABLED_BackupableDBTest, ShareTableFilesWithChecksumsTransition) {
   }
 }
 
-TEST_F(DISABLED_BackupableDBTest, DeleteTmpFiles) {
+TEST_F(BackupableDBTest, DeleteTmpFiles) {
   for (bool shared_checksum : {false, true}) {
     if (shared_checksum) {
       OpenDBAndBackupEngineShareWithChecksum(
@@ -1193,7 +1192,7 @@ TEST_F(DISABLED_BackupableDBTest, DeleteTmpFiles) {
   }
 }
 
-TEST_F(DISABLED_BackupableDBTest, KeepLogFiles) {
+TEST_F(BackupableDBTest, KeepLogFiles) {
   backupable_options_->backup_log_files = false;
   // basically infinite
   options_.WAL_ttl_seconds = 24 * 60 * 60;
@@ -1214,7 +1213,7 @@ TEST_F(DISABLED_BackupableDBTest, KeepLogFiles) {
   AssertBackupConsistency(0, 0, 500, 600, true);
 }
 
-TEST_F(DISABLED_BackupableDBTest, RateLimiting) {
+TEST_F(BackupableDBTest, RateLimiting) {
   size_t const kMicrosPerSec = 1000 * 1000LL;
   uint64_t const MB = 1024 * 1024;
 
@@ -1271,7 +1270,7 @@ TEST_F(DISABLED_BackupableDBTest, RateLimiting) {
   }
 }
 
-TEST_F(DISABLED_BackupableDBTest, ReadOnlyBackupEngine) {
+TEST_F(BackupableDBTest, ReadOnlyBackupEngine) {
   DestroyDB(dbname_, options_);
   OpenDBAndBackupEngine(true);
   FillDB(db_.get(), 0, 100);
@@ -1303,7 +1302,7 @@ TEST_F(DISABLED_BackupableDBTest, ReadOnlyBackupEngine) {
   delete db;
 }
 
-TEST_F(DISABLED_BackupableDBTest, ProgressCallbackDuringBackup) {
+TEST_F(BackupableDBTest, ProgressCallbackDuringBackup) {
   DestroyDB(dbname_, options_);
   OpenDBAndBackupEngine(true);
   FillDB(db_.get(), 0, 100);
@@ -1317,7 +1316,7 @@ TEST_F(DISABLED_BackupableDBTest, ProgressCallbackDuringBackup) {
   DestroyDB(dbname_, options_);
 }
 
-TEST_F(DISABLED_BackupableDBTest, GarbageCollectionBeforeBackup) {
+TEST_F(BackupableDBTest, GarbageCollectionBeforeBackup) {
   DestroyDB(dbname_, options_);
   OpenDBAndBackupEngine(true);
 
@@ -1343,7 +1342,7 @@ TEST_F(DISABLED_BackupableDBTest, GarbageCollectionBeforeBackup) {
 }
 
 // Test that we properly propagate Env failures
-TEST_F(DISABLED_BackupableDBTest, EnvFailures) {
+TEST_F(BackupableDBTest, EnvFailures) {
   BackupEngine* backup_engine;
 
   // get children failure
@@ -1396,7 +1395,7 @@ TEST_F(DISABLED_BackupableDBTest, EnvFailures) {
 
 // Verify manifest can roll while a backup is being created with the old
 // manifest.
-TEST_F(DISABLED_BackupableDBTest, ChangeManifestDuringBackupCreation) {
+TEST_F(BackupableDBTest, ChangeManifestDuringBackupCreation) {
   DestroyDB(dbname_, options_);
   options_.max_manifest_file_size = 0;  // always rollover manifest for file add
   OpenDBAndBackupEngine(true);
@@ -1434,7 +1433,7 @@ TEST_F(DISABLED_BackupableDBTest, ChangeManifestDuringBackupCreation) {
 }
 
 // see https://github.com/facebook/rocksdb/issues/921
-TEST_F(DISABLED_BackupableDBTest, Issue921Test) {
+TEST_F(BackupableDBTest, Issue921Test) {
   BackupEngine* backup_engine;
   backupable_options_->share_table_files = false;
   backup_chroot_env_->CreateDirIfMissing(backupable_options_->backup_dir);
@@ -1445,7 +1444,7 @@ TEST_F(DISABLED_BackupableDBTest, Issue921Test) {
   delete backup_engine;
 }
 
-TEST_F(DISABLED_BackupableDBTest, BackupWithMetadata) {
+TEST_F(BackupableDBTest, BackupWithMetadata) {
   const int keys_iteration = 5000;
   OpenDBAndBackupEngine(true);
   // create five backups
@@ -1468,7 +1467,7 @@ TEST_F(DISABLED_BackupableDBTest, BackupWithMetadata) {
   DestroyDB(dbname_, options_);
 }
 
-TEST_F(DISABLED_BackupableDBTest, BinaryMetadata) {
+TEST_F(BackupableDBTest, BinaryMetadata) {
   OpenDBAndBackupEngine(true);
   std::string binaryMetadata = "abc\ndef";
   binaryMetadata.push_back('\0');
@@ -1486,7 +1485,7 @@ TEST_F(DISABLED_BackupableDBTest, BinaryMetadata) {
   DestroyDB(dbname_, options_);
 }
 
-TEST_F(DISABLED_BackupableDBTest, MetadataTooLarge) {
+TEST_F(BackupableDBTest, MetadataTooLarge) {
   OpenDBAndBackupEngine(true);
   std::string largeMetadata(1024 * 1024 + 1, 0);
   ASSERT_NOK(
@@ -1495,7 +1494,7 @@ TEST_F(DISABLED_BackupableDBTest, MetadataTooLarge) {
   DestroyDB(dbname_, options_);
 }
 
-TEST_F(DISABLED_BackupableDBTest, LimitBackupsOpened) {
+TEST_F(BackupableDBTest, LimitBackupsOpened) {
   // Verify the specified max backups are opened, including skipping over
   // corrupted backups.
   //
@@ -1528,7 +1527,7 @@ TEST_F(DISABLED_BackupableDBTest, LimitBackupsOpened) {
   DestroyDB(dbname_, options_);
 }
 
-TEST_F(DISABLED_BackupableDBTest, CreateWhenLatestBackupCorrupted) {
+TEST_F(BackupableDBTest, CreateWhenLatestBackupCorrupted) {
   // we should pick an ID greater than corrupted backups' IDs so creation can
   // succeed even when latest backup is corrupted.
   const int kNumKeys = 5000;
@@ -1549,7 +1548,7 @@ TEST_F(DISABLED_BackupableDBTest, CreateWhenLatestBackupCorrupted) {
   ASSERT_EQ(2, backup_infos[0].backup_id);
 }
 
-TEST_F(DISABLED_BackupableDBTest, WriteOnlyEngine) {
+TEST_F(BackupableDBTest, WriteOnlyEngine) {
   // Verify we can open a backup engine and create new ones even if reading old
   // backups would fail with IOError. IOError is a more serious condition than
   // corruption and would cause the engine to fail opening. So the only way to

--- a/utilities/blob_db/blob_db_test.cc
+++ b/utilities/blob_db/blob_db_test.cc
@@ -618,7 +618,7 @@ TEST_F(BlobDBTest, MultipleWriters) {
 
   std::vector<port::Thread> workers;
   std::vector<std::map<std::string, std::string>> data_set(10);
-  for (uint32_t i = 0; i < 1; i++)
+  for (uint32_t i = 0; i < 10; i++)
     workers.push_back(port::Thread(
         [&](uint32_t id) {
           Random rnd(301 + id);
@@ -635,7 +635,7 @@ TEST_F(BlobDBTest, MultipleWriters) {
         },
         i));
   std::map<std::string, std::string> data;
-  for (size_t i = 0; i < 1; i++) {
+  for (size_t i = 0; i < 10; i++) {
     workers[i].join();
     data.insert(data_set[i].begin(), data_set[i].end());
   }
@@ -680,7 +680,7 @@ TEST_F(BlobDBTest, GCAfterOverwriteKeys) {
   VerifyDB(data);
 }
 
-TEST_F(BlobDBTest, DISABLED_GCRelocateKeyWhileOverwriting) {
+TEST_F(BlobDBTest, GCRelocateKeyWhileOverwriting) {
   Random rnd(301);
   BlobDBOptions bdb_options;
   bdb_options.min_blob_size = 0;
@@ -711,7 +711,7 @@ TEST_F(BlobDBTest, DISABLED_GCRelocateKeyWhileOverwriting) {
   VerifyDB({{"foo", "v2"}});
 }
 
-TEST_F(BlobDBTest, DISABLED_GCExpiredKeyWhileOverwriting) {
+TEST_F(BlobDBTest, GCExpiredKeyWhileOverwriting) {
   Random rnd(301);
   Options options;
   options.env = mock_env_.get();

--- a/utilities/document/document_db_test.cc
+++ b/utilities/document/document_db_test.cc
@@ -15,14 +15,13 @@
 
 namespace rocksdb {
 
-// NOTE: we will not use DocumentDB in pegasus
-class DISABLED_DocumentDBTest : public testing::Test {
+class DocumentDBTest : public testing::Test {
  public:
-  DISABLED_DocumentDBTest() {
+  DocumentDBTest() {
     dbname_ = test::TmpDir() + "/document_db_test";
     DestroyDB(dbname_, Options());
   }
-  ~DISABLED_DocumentDBTest() {
+  ~DocumentDBTest() {
     delete db_;
     DestroyDB(dbname_, Options());
   }
@@ -67,7 +66,7 @@ class DISABLED_DocumentDBTest : public testing::Test {
   DocumentDB* db_;
 };
 
-TEST_F(DISABLED_DocumentDBTest, SimpleQueryTest) {
+TEST_F(DocumentDBTest, SimpleQueryTest) {
   DocumentDBOptions options;
   DocumentDB::IndexDescriptor index;
   index.description = Parse("{\"name\": 1}");
@@ -139,7 +138,7 @@ TEST_F(DISABLED_DocumentDBTest, SimpleQueryTest) {
   }
 }
 
-TEST_F(DISABLED_DocumentDBTest, ComplexQueryTest) {
+TEST_F(DocumentDBTest, ComplexQueryTest) {
   DocumentDBOptions options;
   DocumentDB::IndexDescriptor priority_index;
   priority_index.description = Parse("{'priority': 1}");

--- a/utilities/simulator_cache/sim_cache_test.cc
+++ b/utilities/simulator_cache/sim_cache_test.cc
@@ -42,7 +42,7 @@ class SimCacheTest : public DBTestBase {
   void InitTable(const Options& options) {
     std::string value(kValueSize, 'a');
     for (size_t i = 0; i < kNumBlocks * 2; i++) {
-      ASSERT_OK(Put(ToString(i), value.c_str(), WriteOptions(), false));
+      ASSERT_OK(Put(ToString(i), value.c_str()));
     }
   }
 

--- a/utilities/transactions/optimistic_transaction_test.cc
+++ b/utilities/transactions/optimistic_transaction_test.cc
@@ -23,15 +23,14 @@ using std::string;
 
 namespace rocksdb {
 
-// PEGASUS: write count of commit may be 0 in DISABLED_OptimisticTransactionTest, which is not supported in pegasus
-class DISABLED_OptimisticTransactionTest : public testing::Test {
+class OptimisticTransactionTest : public testing::Test {
  public:
   OptimisticTransactionDB* txn_db;
   DB* db;
   string dbname;
   Options options;
 
-  DISABLED_OptimisticTransactionTest() {
+  OptimisticTransactionTest() {
     options.create_if_missing = true;
     options.max_write_buffer_number = 2;
     dbname = test::TmpDir() + "/optimistic_transaction_testdb";
@@ -39,7 +38,7 @@ class DISABLED_OptimisticTransactionTest : public testing::Test {
     DestroyDB(dbname, options);
     Open();
   }
-  ~DISABLED_OptimisticTransactionTest() {
+  ~OptimisticTransactionTest() {
     delete txn_db;
     DestroyDB(dbname, options);
   }
@@ -59,7 +58,7 @@ private:
   }
 };
 
-TEST_F(DISABLED_OptimisticTransactionTest, SuccessTest) {
+TEST_F(OptimisticTransactionTest, SuccessTest) {
   WriteOptions write_options;
   ReadOptions read_options;
   string value;
@@ -88,7 +87,7 @@ TEST_F(DISABLED_OptimisticTransactionTest, SuccessTest) {
   delete txn;
 }
 
-TEST_F(DISABLED_OptimisticTransactionTest, WriteConflictTest) {
+TEST_F(OptimisticTransactionTest, WriteConflictTest) {
   WriteOptions write_options;
   ReadOptions read_options;
   string value;
@@ -122,7 +121,7 @@ TEST_F(DISABLED_OptimisticTransactionTest, WriteConflictTest) {
   delete txn;
 }
 
-TEST_F(DISABLED_OptimisticTransactionTest, WriteConflictTest2) {
+TEST_F(OptimisticTransactionTest, WriteConflictTest2) {
   WriteOptions write_options;
   ReadOptions read_options;
   OptimisticTransactionOptions txn_options;
@@ -157,7 +156,7 @@ TEST_F(DISABLED_OptimisticTransactionTest, WriteConflictTest2) {
   delete txn;
 }
 
-TEST_F(DISABLED_OptimisticTransactionTest, ReadConflictTest) {
+TEST_F(OptimisticTransactionTest, ReadConflictTest) {
   WriteOptions write_options;
   ReadOptions read_options, snapshot_read_options;
   OptimisticTransactionOptions txn_options;
@@ -196,7 +195,7 @@ TEST_F(DISABLED_OptimisticTransactionTest, ReadConflictTest) {
   delete txn;
 }
 
-TEST_F(DISABLED_OptimisticTransactionTest, TxnOnlyTest) {
+TEST_F(OptimisticTransactionTest, TxnOnlyTest) {
   // Test to make sure transactions work when there are no other writes in an
   // empty db.
 
@@ -216,7 +215,7 @@ TEST_F(DISABLED_OptimisticTransactionTest, TxnOnlyTest) {
   delete txn;
 }
 
-TEST_F(DISABLED_OptimisticTransactionTest, FlushTest) {
+TEST_F(OptimisticTransactionTest, FlushTest) {
   WriteOptions write_options;
   ReadOptions read_options, snapshot_read_options;
   string value;
@@ -256,7 +255,7 @@ TEST_F(DISABLED_OptimisticTransactionTest, FlushTest) {
   delete txn;
 }
 
-TEST_F(DISABLED_OptimisticTransactionTest, FlushTest2) {
+TEST_F(OptimisticTransactionTest, FlushTest2) {
   WriteOptions write_options;
   ReadOptions read_options, snapshot_read_options;
   string value;
@@ -311,7 +310,7 @@ TEST_F(DISABLED_OptimisticTransactionTest, FlushTest2) {
   delete txn;
 }
 
-TEST_F(DISABLED_OptimisticTransactionTest, NoSnapshotTest) {
+TEST_F(OptimisticTransactionTest, NoSnapshotTest) {
   WriteOptions write_options;
   ReadOptions read_options;
   string value;
@@ -340,7 +339,7 @@ TEST_F(DISABLED_OptimisticTransactionTest, NoSnapshotTest) {
   delete txn;
 }
 
-TEST_F(DISABLED_OptimisticTransactionTest, MultipleSnapshotTest) {
+TEST_F(OptimisticTransactionTest, MultipleSnapshotTest) {
   WriteOptions write_options;
   ReadOptions read_options, snapshot_read_options;
   string value;
@@ -447,7 +446,7 @@ TEST_F(DISABLED_OptimisticTransactionTest, MultipleSnapshotTest) {
   delete txn2;
 }
 
-TEST_F(DISABLED_OptimisticTransactionTest, ColumnFamiliesTest) {
+TEST_F(OptimisticTransactionTest, ColumnFamiliesTest) {
   WriteOptions write_options;
   ReadOptions read_options, snapshot_read_options;
   OptimisticTransactionOptions txn_options;
@@ -606,7 +605,7 @@ TEST_F(DISABLED_OptimisticTransactionTest, ColumnFamiliesTest) {
   }
 }
 
-TEST_F(DISABLED_OptimisticTransactionTest, EmptyTest) {
+TEST_F(OptimisticTransactionTest, EmptyTest) {
   WriteOptions write_options;
   ReadOptions read_options;
   string value;
@@ -643,7 +642,7 @@ TEST_F(DISABLED_OptimisticTransactionTest, EmptyTest) {
   delete txn;
 }
 
-TEST_F(DISABLED_OptimisticTransactionTest, PredicateManyPreceders) {
+TEST_F(OptimisticTransactionTest, PredicateManyPreceders) {
   WriteOptions write_options;
   ReadOptions read_options1, read_options2;
   OptimisticTransactionOptions txn_options;
@@ -707,7 +706,7 @@ TEST_F(DISABLED_OptimisticTransactionTest, PredicateManyPreceders) {
   delete txn2;
 }
 
-TEST_F(DISABLED_OptimisticTransactionTest, LostUpdate) {
+TEST_F(OptimisticTransactionTest, LostUpdate) {
   WriteOptions write_options;
   ReadOptions read_options, read_options1, read_options2;
   OptimisticTransactionOptions txn_options;
@@ -805,7 +804,7 @@ TEST_F(DISABLED_OptimisticTransactionTest, LostUpdate) {
   ASSERT_EQ(value, "8");
 }
 
-TEST_F(DISABLED_OptimisticTransactionTest, UntrackedWrites) {
+TEST_F(OptimisticTransactionTest, UntrackedWrites) {
   WriteOptions write_options;
   ReadOptions read_options;
   string value;
@@ -856,7 +855,7 @@ TEST_F(DISABLED_OptimisticTransactionTest, UntrackedWrites) {
   delete txn;
 }
 
-TEST_F(DISABLED_OptimisticTransactionTest, IteratorTest) {
+TEST_F(OptimisticTransactionTest, IteratorTest) {
   WriteOptions write_options;
   ReadOptions read_options, snapshot_read_options;
   OptimisticTransactionOptions txn_options;
@@ -971,7 +970,7 @@ TEST_F(DISABLED_OptimisticTransactionTest, IteratorTest) {
   delete txn;
 }
 
-TEST_F(DISABLED_OptimisticTransactionTest, SavepointTest) {
+TEST_F(OptimisticTransactionTest, SavepointTest) {
   WriteOptions write_options;
   ReadOptions read_options, snapshot_read_options;
   OptimisticTransactionOptions txn_options;
@@ -1135,7 +1134,7 @@ TEST_F(DISABLED_OptimisticTransactionTest, SavepointTest) {
   delete txn;
 }
 
-TEST_F(DISABLED_OptimisticTransactionTest, UndoGetForUpdateTest) {
+TEST_F(OptimisticTransactionTest, UndoGetForUpdateTest) {
   WriteOptions write_options;
   ReadOptions read_options, snapshot_read_options;
   OptimisticTransactionOptions txn_options;
@@ -1324,7 +1323,7 @@ Status OptimisticTransactionStressTestInserter(OptimisticTransactionDB* db,
 }
 }  // namespace
 
-TEST_F(DISABLED_OptimisticTransactionTest, OptimisticTransactionStressTest) {
+TEST_F(OptimisticTransactionTest, OptimisticTransactionStressTest) {
   const size_t num_threads = 4;
   const size_t num_transactions_per_thread = 10000;
   const size_t num_sets = 3;
@@ -1355,7 +1354,7 @@ TEST_F(DISABLED_OptimisticTransactionTest, OptimisticTransactionStressTest) {
   ASSERT_OK(s);
 }
 
-TEST_F(DISABLED_OptimisticTransactionTest, SequenceNumberAfterRecoverTest) {
+TEST_F(OptimisticTransactionTest, SequenceNumberAfterRecoverTest) {
   WriteOptions write_options;
   OptimisticTransactionOptions transaction_options;
 

--- a/utilities/transactions/transaction_test.cc
+++ b/utilities/transactions/transaction_test.cc
@@ -4,7 +4,7 @@
 //  (found in the LICENSE.Apache file in the root directory).
 
 #ifndef ROCKSDB_LITE
-#ifndef PEGASUS
+
 #ifndef __STDC_FORMAT_MACROS
 #define __STDC_FORMAT_MACROS
 #endif
@@ -4949,5 +4949,5 @@ int main(int argc, char** argv) {
           "SKIPPED as Transactions are not supported in ROCKSDB_LITE\n");
   return 0;
 }
-#endif  // PEGASUS
+
 #endif  // ROCKSDB_LITE

--- a/utilities/transactions/transaction_test.h
+++ b/utilities/transactions/transaction_test.h
@@ -4,7 +4,7 @@
 //  (found in the LICENSE.Apache file in the root directory).
 
 #pragma once
-#ifndef PEGASUS
+
 #ifndef __STDC_FORMAT_MACROS
 #define __STDC_FORMAT_MACROS
 #endif
@@ -55,7 +55,8 @@ class TransactionTest : public ::testing::TestWithParam<
     env = new FaultInjectionTestEnv(Env::Default());
     options.env = env;
     options.concurrent_prepare = std::get<1>(GetParam());
-    dbname = test::TmpDir() + "/transaction_testdb";
+    size_t tid = std::hash<std::thread::id>()(std::this_thread::get_id());
+    dbname = test::TmpDir() + "/transaction_testdb_" + std::to_string(tid);
 
     DestroyDB(dbname, options);
     txn_db_options.transaction_lock_timeout = 0;
@@ -242,5 +243,3 @@ class TransactionTest : public ::testing::TestWithParam<
 class MySQLStyleTransactionTest : public TransactionTest {};
 
 }  // namespace rocksdb
-
-#endif  // PEGASUS

--- a/utilities/transactions/write_prepared_transaction_test.cc
+++ b/utilities/transactions/write_prepared_transaction_test.cc
@@ -155,7 +155,6 @@ TEST(CommitEntry64b, BasicTest) {
   }
 }
 
-#ifndef PEGASUS
 class WritePreparedTxnDBMock : public WritePreparedTxnDB {
  public:
   WritePreparedTxnDBMock(DBImpl* db_impl, TransactionDBOptions& opt)
@@ -1630,7 +1629,6 @@ TEST_P(WritePreparedTransactionTest, Iterate) {
   delete transaction;
 }
 
-#endif  // PEGASUS
 }  // namespace rocksdb
 
 int main(int argc, char** argv) {


### PR DESCRIPTION
- option中增加一个`pegasus_data`用于标记是否是Pegasus使用的rocksdb数据
- 通过配置化, 使得项目本身可运行于非Pegasus模式下
- 去掉之前disable掉的测试代码
- 修复部分单测: 多线程并行测试时的数据目录共享问题(facebook最新master中已修复 https://github.com/facebook/rocksdb/pull/4135), 压缩算法更新导致的压缩率变化问题(https://github.com/facebook/rocksdb/pull/4562) 等
- ldb/sst_dump工具适配`pegasus_data`, 使得工具即可处理Pegasus数据, 也可处理原生数据(不完善, 后需完善 https://github.com/XiaoMi/pegasus/issues/313)
- rename: `value_schema_version` --> `pegasus_data_version`
- 去掉部分未使用的变量或函数, 如: `WriteOptions.given_sequence_number`, `WriteBatch.use_shared_sequence_number_`, `Slice.length()`. 
- 删除 `env_win.h/cc`

当前支持的cmd工具:
```
./ldb dump --path=/path/to/rdb/000048.sst --pegasus_data
./ldb dump_live_files --db=/path/to/rdb/ --try_load_options
./sst_dump --file=/path/to/rdb/ --pegasus_data --command=scan
./sst_dump --file=/path/to/rdb/000048.sst --pegasus_data --command=scan
```
code review建议:
- https://github.com/XiaoMi/pegasus-rocksdb/pull/13 是本修改分支基于tag 5.9.2的变更, 可以更清晰的看到Pegasus分支的所有修改内容
- `*test*.h/cc` 中的修改基本上是revert操作, 可以直接忽略, 或参考 https://github.com/XiaoMi/pegasus-rocksdb/pull/13 看是否有相对于官方分支的修改.