### PR TITLE
refactor: move new added parameters to rear

### DIFF
--- a/db/write_batch_internal.h
+++ b/db/write_batch_internal.h
@@ -175,8 +175,7 @@ class WriteBatchInternal {
                            bool concurrent_memtable_writes = false,
                            SequenceNumber* next_seq = nullptr,
                            bool* has_valid_writes = nullptr,
-                           bool seq_per_batch = false,
-                           uint64_t decree = 0);
+                           bool seq_per_batch = false);
 
   static Status InsertInto(WriteThread::Writer* writer, SequenceNumber sequence,
                            ColumnFamilyMemTables* memtables,
@@ -184,8 +183,7 @@ class WriteBatchInternal {
                            bool ignore_missing_column_families = false,
                            uint64_t log_number = 0, DB* db = nullptr,
                            bool concurrent_memtable_writes = false,
-                           bool seq_per_batch = false,
-                           uint64_t decree = 0);
+                           bool seq_per_batch = false);
 
   static Status Append(WriteBatch* dst, const WriteBatch* src,
                        const bool WAL_only = false);


### PR DESCRIPTION
- 去掉对2个未使用的`InsertInto`构造函数, `WriteBatchInternal::InsertInto`重载函数的修改
- 将Pegasus新增的两个参数 `decree`, `pegasus_data`放到参数列表的最后