### PR TITLE
tools: make tools to be compatible with both original and Pegasus data

### DIFF
--- a/db/version_set.cc
+++ b/db/version_set.cc
@@ -2377,6 +2377,8 @@ std::string Version::DebugString(bool hex, bool print_stats) const {
       AppendNumberTo(&r, files[i]->fd.GetNumber());
       r.push_back(':');
       AppendNumberTo(&r, files[i]->fd.GetFileSize());
+      // TODO(laiyingchun): Pegasus added code to dump seqnos, maybe we should
+      // commit these code to facebook/rocksdb later.
       r.append("[");
       AppendNumberTo(&r, files[i]->smallest_seqno);
       r.append(" .. ");

--- a/db/version_set.cc
+++ b/db/version_set.cc
@@ -2361,11 +2361,11 @@ std::string Version::DebugString(bool hex, bool print_stats) const {
   for (int level = 0; level < storage_info_.num_levels_; level++) {
     // E.g.,
     //   --- level 1 ---
-    //   17:123['a' .. 'd']
-    //   20:43['e' .. 'g']
+    //   17:123[1 .. 124]['a' .. 'd']
+    //   20:43[125 .. 128]['e' .. 'g']
     //
     // if print_stats=true:
-    //   17:123['a' .. 'd'](4096)
+    //   17:123[1 .. 124]['a' .. 'd'](4096)
     r.append("--- level ");
     AppendNumberTo(&r, level);
     r.append(" --- version# ");
@@ -2383,6 +2383,7 @@ std::string Version::DebugString(bool hex, bool print_stats) const {
       AppendNumberTo(&r, files[i]->largest_seqno);
       r.append("]");
       r.append("[");
+      // TODO(laiyingchun): Pegasus data DebugString() not work correctly now.
       r.append(files[i]->smallest.DebugString(hex));
       r.append(" .. ");
       r.append(files[i]->largest.DebugString(hex));

--- a/tools/ldb_cmd_impl.h
+++ b/tools/ldb_cmd_impl.h
@@ -84,12 +84,14 @@ class DBDumperCommand : public LDBCommand {
   bool count_only_;
   bool count_delim_;
   bool print_stats_;
+  bool pegasus_data_;
   std::string path_;
 
   static const std::string ARG_COUNT_ONLY;
   static const std::string ARG_COUNT_DELIM;
   static const std::string ARG_STATS;
   static const std::string ARG_TTL_BUCKET;
+  static const std::string ARG_PEGASUS_DATA;
 };
 
 class InternalDumpCommand : public LDBCommand {

--- a/tools/sst_dump_tool_imp.h
+++ b/tools/sst_dump_tool_imp.h
@@ -18,7 +18,7 @@ namespace rocksdb {
 class SstFileReader {
  public:
   explicit SstFileReader(const std::string& file_name, bool verify_checksum,
-                         bool output_hex);
+                         bool output_hex, Options options);
 
   Status ReadSequential(bool print_kv, uint64_t read_num, bool has_from,
                         const std::string& from_key, bool has_to,
@@ -62,6 +62,7 @@ class SstFileReader {
   std::string file_name_;
   uint64_t read_num_;
   bool verify_checksum_;
+  bool output_hex_;
   EnvOptions soptions_;
 
   // options_ and internal_comparator_ will also be used in


### PR DESCRIPTION
ldb/sst_dump工具适配pegasus_data, 使得工具即可处理Pegasus数据, 也可处理原生数据(不完善, 后需完善 XiaoMi/pegasus#313)

当前支持的CLI:
```
./ldb dump --path=/path/to/rdb/000048.sst --pegasus_data
./ldb dump_live_files --db=/path/to/rdb/ --try_load_options
./sst_dump --file=/path/to/rdb/ --pegasus_data --command=scan
./sst_dump --file=/path/to/rdb/000048.sst --pegasus_data --command=scan
```