### PR TITLE
Bump to v6.6.4 and apply Pegasus changes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -121,4 +121,4 @@ script:
     esac
 notifications:
     email:
-      - leveldb@fb.com
+      - pegasus-help@xiaomi.com

--- a/README.md
+++ b/README.md
@@ -1,8 +1,6 @@
 ## RocksDB: A Persistent Key-Value Store for Flash and RAM Storage
 
-[![Linux/Mac Build Status](https://travis-ci.org/facebook/rocksdb.svg?branch=master)](https://travis-ci.org/facebook/rocksdb)
-[![Windows Build status](https://ci.appveyor.com/api/projects/status/fbgfu0so3afcno78/branch/master?svg=true)](https://ci.appveyor.com/project/Facebook/rocksdb/branch/master)
-[![PPC64le Build Status](http://140.211.168.68:8080/buildStatus/icon?job=Rocksdb)](http://140.211.168.68:8080/job/Rocksdb)
+[![Build Status](https://travis-ci.org/XiaoMi/pegasus-rocksdb.svg?branch=pegasus)](https://travis-ci.org/XiaoMi/pegasus-rocksdb)
 
 RocksDB is developed and maintained by Facebook Database Engineering Team.
 It is built on earlier work on [LevelDB](https://github.com/google/leveldb) by Sanjay Ghemawat (sanjay@google.com)

--- a/db/column_family.cc
+++ b/db/column_family.cc
@@ -1326,6 +1326,8 @@ ColumnFamilySet::ColumnFamilySet(const std::string& dbname,
                                  WriteController* write_controller,
                                  BlockCacheTracer* const block_cache_tracer)
     : max_column_family_(0),
+      pegasus_data_version_(db_options->pegasus_data_version),
+      last_manual_compact_finish_time_(0),
       dummy_cfd_(new ColumnFamilyData(
           0, "", nullptr, nullptr, nullptr, ColumnFamilyOptions(), *db_options,
           env_options, nullptr, block_cache_tracer)),
@@ -1395,6 +1397,20 @@ void ColumnFamilySet::UpdateMaxColumnFamily(uint32_t new_max_column_family) {
 
 size_t ColumnFamilySet::NumberOfColumnFamilies() const {
   return column_families_.size();
+}
+
+uint32_t ColumnFamilySet::GetPegasusDataVersion() const { return pegasus_data_version_; }
+
+void ColumnFamilySet::SetPegasusDataVersion(uint32_t version) {
+  pegasus_data_version_ = version;
+}
+
+uint64_t ColumnFamilySet::GetLastManualCompactFinishTime() const {
+  return last_manual_compact_finish_time_;
+}
+
+void ColumnFamilySet::SetLastManualCompactFinishTime(uint64_t ms) {
+  last_manual_compact_finish_time_ = ms;
 }
 
 // under a DB mutex AND write thread

--- a/db/column_family.h
+++ b/db/column_family.h
@@ -650,7 +650,10 @@ class ColumnFamilySet {
   uint32_t GetMaxColumnFamily();
   void UpdateMaxColumnFamily(uint32_t new_max_column_family);
   size_t NumberOfColumnFamilies() const;
-
+  uint32_t GetPegasusDataVersion() const;
+  void SetPegasusDataVersion(uint32_t version);
+  uint64_t GetLastManualCompactFinishTime() const;
+  void SetLastManualCompactFinishTime(uint64_t ms);
   ColumnFamilyData* CreateColumnFamily(const std::string& name, uint32_t id,
                                        Version* dummy_version,
                                        const ColumnFamilyOptions& options);
@@ -681,6 +684,8 @@ class ColumnFamilySet {
   std::unordered_map<uint32_t, ColumnFamilyData*> column_family_data_;
 
   uint32_t max_column_family_;
+  uint32_t pegasus_data_version_;
+  uint64_t last_manual_compact_finish_time_;
   ColumnFamilyData* dummy_cfd_;
   // We don't hold the refcount here, since default column family always exists
   // We are also not responsible for cleaning up default_cfd_cache_. This is

--- a/db/db_impl/db_impl_compaction_flush.cc
+++ b/db/db_impl/db_impl_compaction_flush.cc
@@ -1641,7 +1641,7 @@ Status DBImpl::FlushMemTable(ColumnFamilyData* cfd,
         nonmem_write_thread_.ExitUnbatched(&nonmem_w);
       }
     }
-    }
+    } // if (!pegasus_data_ || !cfd->mem()->IsEmpty())
   }
   TEST_SYNC_POINT("DBImpl::FlushMemTable:AfterScheduleFlush");
   TEST_SYNC_POINT("DBImpl::FlushMemTable:BeforeWaitForBgFlush");

--- a/db/db_impl/db_impl_compaction_flush.cc
+++ b/db/db_impl/db_impl_compaction_flush.cc
@@ -641,6 +641,29 @@ void DBImpl::NotifyOnFlushCompleted(
 #endif  // ROCKSDB_LITE
 }
 
+Status DBImpl::UpdateManualCompactTime(ColumnFamilyHandle* column_family) {
+  auto cfh = reinterpret_cast<ColumnFamilyHandleImpl*>(column_family);
+  auto cfd = cfh->cfd();
+  uint64_t ms = env_->NowMicros() / 1000;
+
+  InstrumentedMutexLock guard_lock(&mutex_);
+
+  const MutableCFOptions mutable_cf_options = *cfd->GetLatestMutableCFOptions();
+
+  versions_->GetColumnFamilySet()->SetLastManualCompactFinishTime(ms);
+
+  VersionEdit edit;
+  edit.SetColumnFamily(cfd->GetID());
+  edit.SetLastManualCompactFinishTime(ms);
+  Status status = versions_->LogAndApply(cfd, mutable_cf_options, &edit, &mutex_,
+                                         directories_.GetDbDir());
+  ROCKS_LOG_DEBUG(immutable_db_options_.info_log,
+                  "[%s] Apply version edit:\n%s", cfd->GetName().c_str(),
+                  edit.DebugString().data());
+
+  return status;
+}
+
 Status DBImpl::CompactRange(const CompactRangeOptions& options,
                             ColumnFamilyHandle* column_family,
                             const Slice* begin, const Slice* end) {
@@ -777,8 +800,18 @@ Status DBImpl::CompactRange(const CompactRangeOptions& options,
     if (s.ok()) {
       s = ReFitLevel(cfd, final_output_level, options.target_level);
     }
+    VersionStorageInfo::LevelSummaryStorage tmp;
+    ROCKS_LOG_INFO(immutable_db_options_.info_log,
+                   "[%s] Level summary with lsm_state after ReFitLevel: %s\n",
+                   cfd->GetName().c_str(),
+                   cfd->current()->storage_info()->LevelSummary(&tmp));
     ContinueBackgroundWork();
   }
+
+  if (s.ok()) {
+    s = UpdateManualCompactTime(column_family);
+  }
+
   LogFlush(immutable_db_options_.info_log);
 
   {
@@ -1532,6 +1565,9 @@ Status DBImpl::FlushMemTable(ColumnFamilyData* cfd,
     WriteContext context;
     InstrumentedMutexLock guard_lock(&mutex_);
 
+    // ATTENTION(laiyingchun): An optimization to avoid switching empty memtable
+    // for Pegasus(single CF).
+    if (!pegasus_data_ || !cfd->mem()->IsEmpty()) {
     WriteThread::Writer w;
     WriteThread::Writer nonmem_w;
     if (!writes_stopped) {
@@ -1604,6 +1640,7 @@ Status DBImpl::FlushMemTable(ColumnFamilyData* cfd,
       if (two_write_queues_) {
         nonmem_write_thread_.ExitUnbatched(&nonmem_w);
       }
+    }
     }
   }
   TEST_SYNC_POINT("DBImpl::FlushMemTable:AfterScheduleFlush");

--- a/db/db_impl/db_impl_open.cc
+++ b/db/db_impl/db_impl_open.cc
@@ -250,6 +250,7 @@ Status DBImpl::NewDB() {
   new_db.SetLogNumber(0);
   new_db.SetNextFile(2);
   new_db.SetLastSequence(0);
+  new_db.SetPegasusDataVersion(immutable_db_options_.pegasus_data_version);
 
   ROCKS_LOG_INFO(immutable_db_options_.info_log, "Creating manifest 1 \n");
   const std::string manifest = DescriptorFileName(dbname_, 1);

--- a/db/flush_job.cc
+++ b/db/flush_job.cc
@@ -182,6 +182,17 @@ void FlushJob::PickMemTable() {
   // will no longer be picked up for recovery.
   edit_->SetLogNumber(mems_.back()->GetNextLogNumber());
   edit_->SetColumnFamily(cfd_->GetID());
+  if (db_options_.pegasus_data) {
+    // Mark the last sequence/decree of all memtables to be flushed. Although
+    // entries mems are sorted in ascending order by their created, we should
+    // iterate all mems but not take the last one because memtable may be empty.
+    for (auto mem : mems_) {
+      SequenceNumber seq;
+      uint64_t d;
+      mem->GetLastSeqDecree(&seq, &d);
+      edit_->UpdateLastFlushSeqDecree(seq, d);
+    }
+  }
 
   // path 0 for level 0 file.
   meta_.fd = FileDescriptor(versions_->NewFileNumber(), 0, 0);

--- a/db/memtable.cc
+++ b/db/memtable.cc
@@ -95,6 +95,8 @@ MemTable::MemTable(const InternalKeyComparator& cmp,
       earliest_seqno_(latest_seq),
       creation_seq_(latest_seq),
       mem_next_logfile_number_(0),
+      last_sequence_(0),
+      last_decree_(0),
       min_prep_log_referenced_(0),
       locks_(moptions_.inplace_update_support
                  ? moptions_.inplace_update_num_locks

--- a/db/memtable.h
+++ b/db/memtable.h
@@ -434,6 +434,18 @@ class MemTable {
   }
 #endif  // !ROCKSDB_LITE
 
+  void GetLastSeqDecree(SequenceNumber* sequence, uint64_t* decree) const {
+    *sequence = last_sequence_;
+    *decree = last_decree_;
+  }
+
+  void UpdateLastSeqDecree(SequenceNumber sequence, uint64_t decree) {
+    assert(sequence > last_sequence_); // sequence should not be shared
+    assert(decree >= last_decree_); // decree may be shared
+    last_sequence_ = sequence;
+    last_decree_ = decree;
+  }
+
  private:
   enum FlushStateEnum { FLUSH_NOT_REQUESTED, FLUSH_REQUESTED, FLUSH_SCHEDULED };
 
@@ -479,6 +491,10 @@ class MemTable {
 
   // The log files earlier than this number can be deleted.
   uint64_t mem_next_logfile_number_;
+
+  // The last sequence/decree writen into the memtable.
+  SequenceNumber last_sequence_;
+  uint64_t last_decree_;
 
   // the earliest log containing a prepared section
   // which has been inserted into this memtable.

--- a/db/version_edit.cc
+++ b/db/version_edit.cc
@@ -37,6 +37,10 @@ enum Tag : uint32_t {
   // 8 was used for large value refs
   kPrevLogNumber = 9,
   kLastFlushSeqDecree = 10,
+  // On official branch, kMinLogNumberToKeep = 10, but on Pegasus branch we
+  // have introduced a new flag kLastFlushSeqDecree = 10 in previous version,
+  // so intend to keep compatible with old Pegasus version, we have to set
+  // kMinLogNumberToKeep = 11.
   kMinLogNumberToKeep = 11,
   // Ignore-able field
   kDbId = kTagSafeIgnoreMask + 1,

--- a/db/version_edit.cc
+++ b/db/version_edit.cc
@@ -53,7 +53,7 @@ enum Tag : uint32_t {
   kColumnFamilyAdd = 201,
   kColumnFamilyDrop = 202,
   kMaxColumnFamily = 203,
-  kValueSchemaVersion = 204,
+  kPegasusDataVersion = 204,
   kLastManualCompactFinishTime = 205,
 
   kInAtomicGroup = 300,
@@ -189,7 +189,7 @@ bool VersionEdit::EncodeTo(std::string* dst) const {
     PutVarint32Varint32(dst, kMaxColumnFamily, max_column_family_);
   }
   if (has_pegasus_data_version_) {
-    PutVarint32(dst, kValueSchemaVersion);
+    PutVarint32(dst, kPegasusDataVersion);
     PutVarint32(dst, pegasus_data_version_);
   }
   if (has_last_manual_compact_finish_time_) {
@@ -499,7 +499,7 @@ Status VersionEdit::DecodeFrom(const Slice& src) {
         }
         break;
 
-      case kValueSchemaVersion:
+      case kPegasusDataVersion:
         if (GetVarint32(&input, &pegasus_data_version_)) {
           has_pegasus_data_version_ = true;
         } else {

--- a/db/version_edit.cc
+++ b/db/version_edit.cc
@@ -762,7 +762,7 @@ std::string VersionEdit::DebugString(bool hex_key) const {
     r.append(" entries remains");
   }
   if (has_pegasus_data_version_) {
-    r.append("\n  ValueSchemaVersion: ");
+    r.append("\n  PegasusDataVersion: ");
     AppendNumberTo(&r, pegasus_data_version_);
   }
   if (has_last_manual_compact_finish_time_) {

--- a/db/version_edit.h
+++ b/db/version_edit.h
@@ -286,6 +286,38 @@ class VersionEdit {
 
   uint64_t next_file_number() const { return next_file_number_; }
 
+  void SetPegasusDataVersion(uint32_t pegasus_data_version) {
+    has_pegasus_data_version_ = true;
+    pegasus_data_version_ = pegasus_data_version;
+  }
+
+  void SetLastManualCompactFinishTime(uint64_t ms) {
+    has_last_manual_compact_finish_time_ = true;
+    last_manual_compact_finish_time_ = ms;
+  }
+
+  bool HasLastSequence() const {
+    return has_last_sequence_;
+  }
+
+  SequenceNumber GetLastSequence() const {
+    return last_sequence_;
+  }
+
+  void GetLastFlushSeqDecree(SequenceNumber* sequence, uint64_t* decree) const {
+    *sequence = last_flush_sequence_;
+    *decree = last_flush_decree_;
+  }
+
+  void UpdateLastFlushSeqDecree(SequenceNumber sequence, uint64_t decree) {
+    if (sequence > last_flush_sequence_) {
+      assert(decree >= last_flush_decree_);
+      last_flush_sequence_ = sequence;
+      last_flush_decree_ = decree;
+      has_last_flush_seq_decree_ = true;
+    }
+  }
+
   // Add the specified file at the specified number.
   // REQUIRES: This version has not been saved (see VersionSet::SaveTo)
   // REQUIRES: "smallest" and "largest" are smallest and largest keys in file
@@ -381,17 +413,26 @@ class VersionEdit {
   uint64_t prev_log_number_;
   uint64_t next_file_number_;
   uint32_t max_column_family_;
+  uint32_t pegasus_data_version_;
+  uint64_t last_manual_compact_finish_time_;
   // The most recent WAL log number that is deleted
   uint64_t min_log_number_to_keep_;
   SequenceNumber last_sequence_;
+  // Used to mark the last sequence/decree of flushed memtables.
+  SequenceNumber last_flush_sequence_;
+  uint64_t last_flush_decree_;
+
   bool has_db_id_;
   bool has_comparator_;
   bool has_log_number_;
   bool has_prev_log_number_;
   bool has_next_file_number_;
   bool has_last_sequence_;
+  bool has_last_flush_seq_decree_;
   bool has_max_column_family_;
   bool has_min_log_number_to_keep_;
+  bool has_pegasus_data_version_;
+  bool has_last_manual_compact_finish_time_;
 
   DeletedFileSet deleted_files_;
   std::vector<std::pair<int, FileMetaData>> new_files_;

--- a/db/version_set.cc
+++ b/db/version_set.cc
@@ -3425,7 +3425,6 @@ std::string Version::DebugString(bool hex, bool print_stats) const {
       AppendNumberTo(&r, files[i]->fd.largest_seqno);
       r.append("]");
       r.append("[");
-      // TODO(laiyingchun): Pegasus data DebugString() not work correctly now.
       r.append(files[i]->smallest.DebugString(hex));
       r.append(" .. ");
       r.append(files[i]->largest.DebugString(hex));

--- a/db/version_set.cc
+++ b/db/version_set.cc
@@ -1744,6 +1744,8 @@ Version::Version(ColumnFamilyData* column_family_data, VersionSet* vset,
       next_(this),
       prev_(this),
       refs_(0),
+      last_flush_sequence_(0),
+      last_flush_decree_(0),
       env_options_(env_opt),
       mutable_cf_options_(mutable_cf_options),
       version_number_(version_number) {}
@@ -3423,6 +3425,7 @@ std::string Version::DebugString(bool hex, bool print_stats) const {
       AppendNumberTo(&r, files[i]->fd.largest_seqno);
       r.append("]");
       r.append("[");
+      // TODO(laiyingchun): Pegasus data DebugString() not work correctly now.
       r.append(files[i]->smallest.DebugString(hex));
       r.append(" .. ");
       r.append(files[i]->largest.DebugString(hex));
@@ -3563,6 +3566,14 @@ void VersionSet::AppendVersion(ColumnFamilyData* column_family_data,
   assert(v != current);
   if (current != nullptr) {
     assert(current->refs_ > 0);
+    if (db_options_->pegasus_data) {
+      // inherit last sequence/decree from old version, but for flush the old
+      // value would not take effect.
+      SequenceNumber seq;
+      uint64_t d;
+      current->GetLastFlushSeqDecree(&seq, &d);
+      v->UpdateLastFlushSeqDecreeIfNeeded(seq, d);
+    }
     current->Unref();
   }
   column_family_data->SetCurrent(v);
@@ -3758,6 +3769,9 @@ Status VersionSet::ProcessManifestWrites(
       first_writer.edit_list.front()->SetMaxColumnFamily(
           column_family_set_->GetMaxColumnFamily());
     }
+    // also we need to persist Pegasus data version
+    first_writer.edit_list.front()->SetPegasusDataVersion(
+        column_family_set_->GetPegasusDataVersion());
   }
 
   {
@@ -3903,6 +3917,13 @@ Status VersionSet::ProcessManifestWrites(
             max_log_number_in_batch =
                 std::max(max_log_number_in_batch, e->log_number_);
           }
+          if (db_options_->pegasus_data) {
+            // update last flush sequence/decree from VersionEdit
+            SequenceNumber seq;
+            uint64_t d;
+            e->GetLastFlushSeqDecree(&seq, &d);
+            version->UpdateLastFlushSeqDecreeIfNeeded(seq, d);
+          }
         }
         if (max_log_number_in_batch != 0) {
           assert(version->cfd_->GetLogNumber() <= max_log_number_in_batch);
@@ -3950,7 +3971,7 @@ Status VersionSet::ProcessManifestWrites(
       ROCKS_LOG_INFO(db_options_->info_log,
                      "Deleting manifest %" PRIu64 " current manifest %" PRIu64
                      "\n",
-                     manifest_file_number_, pending_manifest_file_number_);
+                     pending_manifest_file_number_, manifest_file_number_);
       env_->DeleteFile(
           DescriptorFileName(dbname_, pending_manifest_file_number_));
     }
@@ -4074,6 +4095,13 @@ void VersionSet::LogAndApplyCFHelper(VersionEdit* edit) {
   // last_allocated_sequence_ as the last sequence.
   edit->SetLastSequence(db_options_->two_write_queues ? last_allocated_sequence_
                                                       : last_sequence_);
+  if (db_options_->pegasus_data) {
+    assert(column_family_set_->NumberOfColumnFamilies() == 1u);
+    SequenceNumber seq;
+    uint64_t d;
+    column_family_set_->GetDefault()->current()->GetLastFlushSeqDecree(&seq, &d);
+    edit->UpdateLastFlushSeqDecree(seq, d);
+  }
   if (edit->is_column_family_drop_) {
     // if we drop column family, we have to make sure to save max column family,
     // so that we don't reuse existing ID
@@ -4106,6 +4134,17 @@ Status VersionSet::LogAndApplyHelper(ColumnFamilyData* cfd,
   // last_allocated_sequence_ as the last sequence.
   edit->SetLastSequence(db_options_->two_write_queues ? last_allocated_sequence_
                                                       : last_sequence_);
+
+  if (db_options_->pegasus_data) {
+    assert(column_family_set_->NumberOfColumnFamilies() == 1u);
+    SequenceNumber seq;
+    uint64_t d;
+    column_family_set_->GetDefault()->current()->GetLastFlushSeqDecree(&seq, &d);
+    edit->UpdateLastFlushSeqDecree(seq, d);
+
+    uint64_t ms = column_family_set_->GetLastManualCompactFinishTime();
+    edit->SetLastManualCompactFinishTime(ms);
+  }
 
   Status s = builder->Apply(edit);
 
@@ -4254,6 +4293,21 @@ Status VersionSet::ExtractInfoFromVersionEdit(
   if (from_edit.has_last_sequence_) {
     version_edit_params->SetLastSequence(from_edit.last_sequence_);
   }
+
+  if (from_edit.has_pegasus_data_version_) {
+    version_edit_params->SetPegasusDataVersion(from_edit.pegasus_data_version_);
+  }
+  
+  if (from_edit.has_last_manual_compact_finish_time_) {
+    version_edit_params->SetLastManualCompactFinishTime(
+        from_edit.last_manual_compact_finish_time_);
+  }
+  
+  if (from_edit.has_last_flush_seq_decree_) {
+    version_edit_params->UpdateLastFlushSeqDecree(
+        from_edit.last_flush_sequence_, from_edit.last_flush_decree_);
+  }
+
   return Status::OK();
 }
 
@@ -4434,6 +4488,13 @@ Status VersionSet::Recover(
       s = Status::Corruption("no meta-lognumber entry in descriptor");
     } else if (!version_edit_params.has_last_sequence_) {
       s = Status::Corruption("no last-sequence-number entry in descriptor");
+    } else if (!version_edit_params.has_pegasus_data_version_) {
+      if (db_options_->pegasus_data) {
+        s = Status::Corruption("no pegasus-data-version entry in descriptor");
+      }
+    } else if (!version_edit_params.has_last_manual_compact_finish_time_) {
+      ROCKS_LOG_INFO(db_options_->info_log,
+                     "no last-manual-compact-finish-time entry in descriptor");
     }
 
     if (!version_edit_params.has_prev_log_number_) {
@@ -4442,6 +4503,10 @@ Status VersionSet::Recover(
 
     column_family_set_->UpdateMaxColumnFamily(
         version_edit_params.max_column_family_);
+    column_family_set_->SetPegasusDataVersion(
+        version_edit_params.pegasus_data_version_);
+    column_family_set_->SetLastManualCompactFinishTime(
+        version_edit_params.last_manual_compact_finish_time_);
 
     // When reading DB generated using old release, min_log_number_to_keep=0.
     // All log files will be scanned for potential prepare entries.
@@ -4501,6 +4566,14 @@ Status VersionSet::Recover(
                                current_version_number_++);
       builder->SaveTo(v->storage_info());
 
+      if (db_options_->pegasus_data) {
+        // update last flush sequence/decree
+        SequenceNumber sequence;
+        uint64_t decree = 0;
+        version_edit_params.GetLastFlushSeqDecree(&sequence, &decree);
+        v->UpdateLastFlushSeqDecreeIfNeeded(sequence, decree);
+      }
+
       // Install recovered version
       v->PrepareApply(*cfd->GetLatestMutableCFOptions(),
           !(db_options_->skip_stats_update_on_db_open));
@@ -4520,11 +4593,24 @@ Status VersionSet::Recover(
         "manifest_file_number is %" PRIu64 ", next_file_number is %" PRIu64
         ", last_sequence is %" PRIu64 ", log_number is %" PRIu64
         ",prev_log_number is %" PRIu64 ",max_column_family is %" PRIu32
-        ",min_log_number_to_keep is %" PRIu64 "\n",
+        ",min_log_number_to_keep is %" PRIu64
+        ",pegasus_data_version is %" PRIu32
+        ",last_manual_compact_finish_time is %" PRIu64 "\n",
         manifest_path.c_str(), manifest_file_number_, next_file_number_.load(),
         last_sequence_.load(), version_edit_params.log_number_,
         prev_log_number_, column_family_set_->GetMaxColumnFamily(),
-        min_log_number_to_keep_2pc());
+        min_log_number_to_keep_2pc(),
+        column_family_set_->GetPegasusDataVersion(),
+        column_family_set_->GetLastManualCompactFinishTime());
+
+    if (db_options_->pegasus_data) {
+      // For Pegasus, we have disabled WAL, so we need to reset last_sequence to
+      // last_flush_sequence.
+      last_sequence_ = LastFlushSequence();
+      ROCKS_LOG_INFO(db_options_->info_log,
+                     "Reset last_sequence to last_flush_sequence: %" PRIu64,
+                     last_sequence_.load());
+    }
 
     for (auto cfd : *column_family_set_) {
       if (cfd->IsDropped()) {
@@ -4720,6 +4806,7 @@ Status VersionSet::DumpManifest(Options& options, std::string& dscname,
   std::unordered_map<uint32_t, std::string> comparators;
   std::unordered_map<uint32_t, std::unique_ptr<BaseReferencedVersionBuilder>>
       builders;
+  std::unordered_map<uint32_t, std::pair<uint64_t, uint64_t>> last_flush_seq_decree_map;
 
   // add default column family
   VersionEdit default_cf_edit;
@@ -4829,12 +4916,29 @@ Status VersionSet::DumpManifest(Options& options, std::string& dscname,
         have_last_sequence = true;
       }
 
+      if (edit.has_last_flush_seq_decree_) {
+        auto& p = last_flush_seq_decree_map[edit.column_family_];
+        if (edit.last_flush_sequence_ > p.first) {
+          assert(edit.last_flush_decree_ >= p.second);
+          p.first = edit.last_flush_sequence_;
+          p.second = edit.last_flush_decree_;
+        }
+      }
+
       if (edit.has_max_column_family_) {
         column_family_set_->UpdateMaxColumnFamily(edit.max_column_family_);
       }
 
       if (edit.has_min_log_number_to_keep_) {
         MarkMinLogNumberToKeep2PC(edit.min_log_number_to_keep_);
+      }
+
+      if (edit.has_pegasus_data_version_) {
+        column_family_set_->SetPegasusDataVersion(edit.pegasus_data_version_);
+      }
+
+      if (edit.has_last_manual_compact_finish_time_) {
+        column_family_set_->SetLastManualCompactFinishTime(edit.last_manual_compact_finish_time_);
       }
     }
   }
@@ -4867,6 +4971,10 @@ Status VersionSet::DumpManifest(Options& options, std::string& dscname,
                                *cfd->GetLatestMutableCFOptions(),
                                current_version_number_++);
       builder->SaveTo(v->storage_info());
+
+      auto& p = last_flush_seq_decree_map[cfd->GetID()];
+      v->UpdateLastFlushSeqDecreeIfNeeded(p.first, p.second);
+
       v->PrepareApply(*cfd->GetLatestMutableCFOptions(), false);
 
       printf("--------------- Column family \"%s\"  (ID %" PRIu32
@@ -4879,6 +4987,11 @@ Status VersionSet::DumpManifest(Options& options, std::string& dscname,
       } else {
         printf("comparator: <NO COMPARATOR>\n");
       }
+      SequenceNumber seq;
+      uint64_t d;
+      v->GetLastFlushSeqDecree(&seq, &d);
+      printf("last flush sequence: %" PRIu64 "\n", seq);
+      printf("last flush decree: %" PRIu64 "\n", d);
       printf("%s \n", v->DebugString(hex).c_str());
       delete v;
     }
@@ -4889,13 +5002,18 @@ Status VersionSet::DumpManifest(Options& options, std::string& dscname,
     last_sequence_ = last_sequence;
     prev_log_number_ = previous_log_number;
 
+    auto& p = last_flush_seq_decree_map[0]; // default column family
     printf("next_file_number %" PRIu64 " last_sequence %" PRIu64
            "  prev_log_number %" PRIu64 " max_column_family %" PRIu32
-           " min_log_number_to_keep "
-           "%" PRIu64 "\n",
+           " min_log_number_to_keep %" PRIu64
+           " last_flush_sequence %" PRIu64 " last_flush_decree %" PRIu64
+           " pegasus_data_version  %" PRIu32 " last_manual_compact_finish_time %" PRIu64 "\n",
            next_file_number_.load(), last_sequence, previous_log_number,
            column_family_set_->GetMaxColumnFamily(),
-           min_log_number_to_keep_2pc());
+           min_log_number_to_keep_2pc(),
+           p.first, p.second,
+           column_family_set_->GetPegasusDataVersion(),
+           column_family_set_->GetLastManualCompactFinishTime());
   }
 
   return s;

--- a/db/write_batch.cc
+++ b/db/write_batch.cc
@@ -1988,7 +1988,7 @@ Status WriteBatchInternal::InsertInto(
       sequence, memtables, flush_scheduler, trim_history_scheduler,
       ignore_missing_column_families, recovery_log_number, db,
       concurrent_memtable_writes, nullptr /*has_valid_writes*/, seq_per_batch,
-      batch_per_txn, false, decree, pegasus_data);
+      batch_per_txn, false /*hint_per_batch*/, decree, pegasus_data);
   for (auto w : write_group) {
     if (w->CallbackFailed()) {
       continue;

--- a/db/write_batch.cc
+++ b/db/write_batch.cc
@@ -1231,6 +1231,9 @@ class MemTableInserter : public WriteBatch::Handler {
   using HintMapType = std::aligned_storage<sizeof(HintMap)>::type;
   HintMapType hint_;
 
+  uint64_t decree_;
+  bool pegasus_data_;
+
   HintMap& GetHintMap() {
     assert(hint_per_batch_);
     if (!hint_created_) {
@@ -1273,7 +1276,8 @@ class MemTableInserter : public WriteBatch::Handler {
                    uint64_t recovering_log_number, DB* db,
                    bool concurrent_memtable_writes,
                    bool* has_valid_writes = nullptr, bool seq_per_batch = false,
-                   bool batch_per_txn = true, bool hint_per_batch = false)
+                   bool batch_per_txn = true, bool hint_per_batch = false,
+                   uint64_t decree = 0, bool pegasus_data = false)
       : sequence_(_sequence),
         cf_mems_(cf_mems),
         flush_scheduler_(flush_scheduler),
@@ -1299,7 +1303,9 @@ class MemTableInserter : public WriteBatch::Handler {
         duplicate_detector_(),
         dup_dectector_on_(false),
         hint_per_batch_(hint_per_batch),
-        hint_created_(false) {
+        hint_created_(false),
+        decree_(decree),
+        pegasus_data_(pegasus_data) {
     assert(cf_mems_);
   }
 
@@ -1495,6 +1501,9 @@ class MemTableInserter : public WriteBatch::Handler {
     // Since all Puts are logged in transaction logs (if enabled), always bump
     // sequence number. Even if the update eventually fails and does not result
     // in memtable add/update.
+    if (pegasus_data_) {
+      mem->UpdateLastSeqDecree(sequence_, decree_);
+    }
     MaybeAdvanceSeq();
     CheckMemtableFull();
     return ret_status;
@@ -1518,6 +1527,9 @@ class MemTableInserter : public WriteBatch::Handler {
       ret_status = Status::TryAgain("key+seq exists");
       const bool BATCH_BOUNDRY = true;
       MaybeAdvanceSeq(BATCH_BOUNDRY);
+    }
+    if (pegasus_data_) {
+      mem->UpdateLastSeqDecree(sequence_, decree_);
     }
     MaybeAdvanceSeq();
     CheckMemtableFull();
@@ -1759,6 +1771,9 @@ class MemTableInserter : public WriteBatch::Handler {
       // the rebuilding transaction object.
       WriteBatchInternal::Merge(rebuilding_trx_, column_family_id, key, value);
     }
+    if (pegasus_data_) {
+      mem->UpdateLastSeqDecree(sequence_, decree_);
+    }
     MaybeAdvanceSeq();
     CheckMemtableFull();
     return ret_status;
@@ -1967,12 +1982,13 @@ Status WriteBatchInternal::InsertInto(
     ColumnFamilyMemTables* memtables, FlushScheduler* flush_scheduler,
     TrimHistoryScheduler* trim_history_scheduler,
     bool ignore_missing_column_families, uint64_t recovery_log_number, DB* db,
-    bool concurrent_memtable_writes, bool seq_per_batch, bool batch_per_txn) {
+    bool concurrent_memtable_writes, bool seq_per_batch, bool batch_per_txn,
+    uint64_t decree, bool pegasus_data) {
   MemTableInserter inserter(
       sequence, memtables, flush_scheduler, trim_history_scheduler,
       ignore_missing_column_families, recovery_log_number, db,
       concurrent_memtable_writes, nullptr /*has_valid_writes*/, seq_per_batch,
-      batch_per_txn);
+      batch_per_txn, false, decree, pegasus_data);
   for (auto w : write_group) {
     if (w->CallbackFailed()) {
       continue;

--- a/db/write_batch_internal.h
+++ b/db/write_batch_internal.h
@@ -167,7 +167,8 @@ class WriteBatchInternal {
       TrimHistoryScheduler* trim_history_scheduler,
       bool ignore_missing_column_families = false, uint64_t log_number = 0,
       DB* db = nullptr, bool concurrent_memtable_writes = false,
-      bool seq_per_batch = false, bool batch_per_txn = true);
+      bool seq_per_batch = false, bool batch_per_txn = true,
+      uint64_t decree = 0, bool pegasus_data = false);
 
   // Convenience form of InsertInto when you have only one batch
   // next_seq returns the seq after last sequence number used in MemTable insert

--- a/include/rocksdb/db.h
+++ b/include/rocksdb/db.h
@@ -1130,6 +1130,14 @@ class DB {
   // updated, false if user attempted to call if with seqnum <= current value.
   virtual bool SetPreserveDeletesSequenceNumber(SequenceNumber seqnum) = 0;
 
+  // The last flushed decree.
+  virtual uint64_t GetLastFlushedDecree() const { return 0; }
+
+  // The Pegasus data version.
+  virtual uint32_t GetPegasusDataVersion() const { return 0; }
+
+  virtual uint64_t GetLastManualCompactFinishTime() const { return 0; }
+
 #ifndef ROCKSDB_LITE
 
   // Prevent file deletions. Compactions will continue to occur,
@@ -1167,6 +1175,14 @@ class DB {
   virtual Status GetLiveFiles(std::vector<std::string>&,
                               uint64_t* manifest_file_size,
                               bool flush_memtable = true) = 0;
+
+  // Retrieve the list of all files in the database.
+  virtual Status GetLiveFilesQuick(std::vector<std::string>& /*ret*/,
+                                   uint64_t* /*manifest_file_size*/,
+                                   SequenceNumber* /*last_sequence*/,
+                                   uint64_t* /*last_decree*/) const {
+    return Status::NotSupported();
+  }
 
   // Retrieve the sorted list of all wal files with earliest file first
   virtual Status GetSortedWalFiles(VectorLogPtr& files) = 0;

--- a/include/rocksdb/options.h
+++ b/include/rocksdb/options.h
@@ -1104,6 +1104,14 @@ struct DBOptions {
   //
   // Default: 0
   size_t log_readahead_size = 0;
+
+  // Whether the data is for Pegasus.
+  // Default: false
+  bool pegasus_data = false;
+
+  // Pegasus data version.
+  // Default: 0
+  uint32_t pegasus_data_version = 0;
 };
 
 // Options to control the behavior of a database (passed to DB::Open)
@@ -1366,6 +1374,9 @@ struct WriteOptions {
   // and the API is subject to change.
   const Slice* timestamp;
 
+  // Decree is an value affiliated to the write.
+  uint64_t given_decree;
+
   WriteOptions()
       : sync(false),
         disableWAL(false),
@@ -1373,7 +1384,8 @@ struct WriteOptions {
         no_slowdown(false),
         low_pri(false),
         memtable_insert_hint_per_batch(false),
-        timestamp(nullptr) {}
+        timestamp(nullptr),
+        given_decree(0) {}
 };
 
 // Options that control flush operations

--- a/include/rocksdb/utilities/checkpoint.h
+++ b/include/rocksdb/utilities/checkpoint.h
@@ -50,6 +50,13 @@ class Checkpoint {
                                     const std::string& export_dir,
                                     ExportImportFilesMetaData** metadata);
 
+  // Quickly build an openable snapshot of RocksDB on the same disk, will not
+  // wait flush before generate checkpoint.
+  // The decree of the checkpoint generated will be returned through
+  // *checkpoint_decree, if checkpoint_decree not nullptr
+  // The directory should not already exist and will be created by this API.
+  virtual Status CreateCheckpointQuick(const std::string& checkpoint_dir,
+                                       /*output*/ uint64_t* checkpoint_decree);
   virtual ~Checkpoint() {}
 };
 

--- a/options/db_options.cc
+++ b/options/db_options.cc
@@ -89,7 +89,9 @@ ImmutableDBOptions::ImmutableDBOptions(const DBOptions& options)
       avoid_unnecessary_blocking_io(options.avoid_unnecessary_blocking_io),
       persist_stats_to_disk(options.persist_stats_to_disk),
       write_dbid_to_manifest(options.write_dbid_to_manifest),
-      log_readahead_size(options.log_readahead_size) {
+      log_readahead_size(options.log_readahead_size),
+      pegasus_data(options.pegasus_data),
+      pegasus_data_version(options.pegasus_data_version) {
 }
 
 void ImmutableDBOptions::Dump(Logger* log) const {
@@ -238,6 +240,9 @@ void ImmutableDBOptions::Dump(Logger* log) const {
   ROCKS_LOG_HEADER(
       log, "                Options.log_readahead_size: %" ROCKSDB_PRIszt,
       log_readahead_size);
+  ROCKS_LOG_HEADER(log, "            Options.pegasus_data: %d", pegasus_data);
+  ROCKS_LOG_HEADER(log, "            Options.pegasus_data_version: %d",
+                   pegasus_data_version);
 }
 
 MutableDBOptions::MutableDBOptions()

--- a/options/db_options.h
+++ b/options/db_options.h
@@ -85,6 +85,8 @@ struct ImmutableDBOptions {
   bool persist_stats_to_disk;
   bool write_dbid_to_manifest;
   size_t log_readahead_size;
+  bool pegasus_data;
+  uint32_t pegasus_data_version;
 };
 
 struct MutableDBOptions {

--- a/options/options_helper.cc
+++ b/options/options_helper.cc
@@ -141,6 +141,11 @@ DBOptions BuildDBOptions(const ImmutableDBOptions& immutable_db_options,
   options.avoid_unnecessary_blocking_io =
       immutable_db_options.avoid_unnecessary_blocking_io;
   options.log_readahead_size = immutable_db_options.log_readahead_size;
+  options.pegasus_data =
+      immutable_db_options.pegasus_data;
+  options.pegasus_data_version =
+      immutable_db_options.pegasus_data_version;
+
   return options;
 }
 
@@ -1674,6 +1679,14 @@ std::unordered_map<std::string, OptionTypeInfo>
         {"log_readahead_size",
          {offsetof(struct DBOptions, log_readahead_size), OptionType::kSizeT,
           OptionVerificationType::kNormal, false, 0}},
+        {"pegasus_data",
+         {offsetof(struct DBOptions, pegasus_data), OptionType::kBoolean,
+          OptionVerificationType::kNormal, false,
+          offsetof(struct ImmutableDBOptions, pegasus_data)}},
+        {"pegasus_data_version",
+         {offsetof(struct DBOptions, pegasus_data_version), OptionType::kUInt32T,
+          OptionVerificationType::kNormal, false,
+          offsetof(struct ImmutableDBOptions, pegasus_data_version)}},
 };
 
 std::unordered_map<std::string, BlockBasedTableOptions::IndexType>

--- a/options/options_settable_test.cc
+++ b/options/options_settable_test.cc
@@ -298,7 +298,9 @@ TEST_F(OptionsSettableTest, DBOptionsAllFieldsSettable) {
                              "atomic_flush=false;"
                              "avoid_unnecessary_blocking_io=false;"
                              "log_readahead_size=0;"
-                             "write_dbid_to_manifest=false",
+                             "write_dbid_to_manifest=false;"
+                             "pegasus_data=false;"
+                             "pegasus_data_version=0;",
                              new_options));
 
   ASSERT_EQ(unset_bytes_base, NumUnsetBytes(new_options_ptr, sizeof(DBOptions),

--- a/test_util/testutil.cc
+++ b/test_util/testutil.cc
@@ -268,6 +268,7 @@ void RandomInitDBOptions(DBOptions* db_opt, Random* rnd) {
   db_opt->recycle_log_file_num = rnd->Uniform(2);
   db_opt->avoid_flush_during_recovery = rnd->Uniform(2);
   db_opt->avoid_flush_during_shutdown = rnd->Uniform(2);
+  db_opt->pegasus_data = rnd->Uniform(2);
 
   // int options
   db_opt->max_background_compactions = rnd->Uniform(100);
@@ -289,6 +290,7 @@ void RandomInitDBOptions(DBOptions* db_opt, Random* rnd) {
 
   // uint32_t options
   db_opt->max_subcompactions = rnd->Uniform(100000);
+  db_opt->pegasus_data_version = rnd->Uniform(100000);
 
   // uint64_t options
   static const uint64_t uint_max = static_cast<uint64_t>(UINT_MAX);

--- a/tools/ldb_cmd_impl.h
+++ b/tools/ldb_cmd_impl.h
@@ -84,12 +84,14 @@ class DBDumperCommand : public LDBCommand {
   bool count_only_;
   bool count_delim_;
   bool print_stats_;
+  bool pegasus_data_;
   std::string path_;
 
   static const std::string ARG_COUNT_ONLY;
   static const std::string ARG_COUNT_DELIM;
   static const std::string ARG_STATS;
   static const std::string ARG_TTL_BUCKET;
+  static const std::string ARG_PEGASUS_DATA;
 };
 
 class InternalDumpCommand : public LDBCommand {

--- a/util/compression.h
+++ b/util/compression.h
@@ -1048,7 +1048,6 @@ inline bool LZ4_Compress(const CompressionInfo& info,
 #else   // up to r123
   outlen = LZ4_compress_limitedOutput(input, &(*output)[output_header_len],
                                       static_cast<int>(length), compress_bound);
-  (void)ctx;
 #endif  // LZ4_VERSION_NUMBER >= 10400
 
   if (outlen == 0) {
@@ -1113,7 +1112,6 @@ inline CacheAllocationPtr LZ4_Uncompress(const UncompressionInfo& info,
   *decompress_size = LZ4_decompress_safe(input_data, output.get(),
                                          static_cast<int>(input_length),
                                          static_cast<int>(output_len));
-  (void)ctx;
 #endif  // LZ4_VERSION_NUMBER >= 10400
 
   if (*decompress_size < 0) {

--- a/utilities/checkpoint/checkpoint_impl.cc
+++ b/utilities/checkpoint/checkpoint_impl.cc
@@ -16,6 +16,7 @@
 #include <string>
 #include <vector>
 
+#include "db/log_writer.h"
 #include "db/wal_manager.h"
 #include "file/file_util.h"
 #include "file/filename.h"
@@ -67,10 +68,17 @@ Status Checkpoint::ExportColumnFamily(
   return Status::NotSupported("");
 }
 
+Status Checkpoint::CreateCheckpointQuick(const std::string& /*checkpoint_dir*/,
+                                         uint64_t* /*checkpoint_decree*/) {
+  return Status::NotSupported("");
+}
+
 // Builds an openable snapshot of RocksDB
 Status CheckpointImpl::CreateCheckpoint(const std::string& checkpoint_dir,
                                         uint64_t log_size_for_flush) {
   DBOptions db_options = db_->GetDBOptions();
+  // ATTENTION(laiyingchun): log_size_for_flush should always be 0 in pegasus.
+  assert(!db_options.pegasus_data || log_size_for_flush == 0);
 
   Status s = db_->GetEnv()->FileExists(checkpoint_dir);
   if (s.ok()) {
@@ -510,6 +518,239 @@ Status CheckpointImpl::ExportFilesInMetaData(
 
   return s;
 }
+
+struct LogReporter : public log::Reader::Reporter {
+  Status* status = nullptr;
+
+  void Corruption(size_t /*bytes*/, const Status& s) override {
+    if (this->status && this->status->ok()) *this->status = s;
+  }
+};
+
+static Status ModifyManifestFileLastSeq(Env* env, const DBOptions& db_options,
+                                        const std::string& file_name,
+                                        SequenceNumber last_seq) {
+  Status s;
+  EnvOptions env_options(db_options);
+  std::string tmp_file = file_name + ".tmp";
+  s = env->RenameFile(file_name, tmp_file);
+  if (!s.ok()) {
+    return s;
+  }
+
+  std::unique_ptr<SequentialFileReader> file_reader;
+  {
+    std::unique_ptr<SequentialFile> file;
+    s = env->NewSequentialFile(tmp_file, &file, env_options);
+    if (!s.ok()) {
+      return s;
+    }
+
+    file_reader.reset(new SequentialFileReader(std::move(file), tmp_file));
+  }
+
+  std::unique_ptr<log::Writer> file_writer;
+  {
+    std::unique_ptr<WritableFile> file;
+    EnvOptions opt_env_opts = env->OptimizeForManifestWrite(env_options);
+    s = env->NewWritableFile(file_name, &file, opt_env_opts);
+    if (!s.ok()) {
+      return s;
+    }
+
+    file->SetPreallocationBlockSize(db_options.manifest_preallocation_size);
+    std::unique_ptr<WritableFileWriter> writer(
+        new WritableFileWriter(std::move(file), file_name, opt_env_opts));
+    file_writer.reset(new log::Writer(std::move(writer),
+                                      0 /*log_number. log_number is useless when recycle_log_files is false.*/,
+                                      false /*recycle_log_files*/,
+                                      false /*manual_flush*/));
+  }
+
+  {
+    LogReporter reporter;
+    reporter.status = &s;
+    log::Reader reader(db_options.info_log /*actually not used in Reader.*/,
+                       std::move(file_reader), &reporter, true /*checksum*/,
+                       0 /*log_num. log_number is useless when recycle_log_files is false in writer.*/);
+    Slice record;
+    std::string scratch;
+    while (reader.ReadRecord(&record, &scratch) && s.ok()) {
+      VersionEdit edit;
+      s = edit.DecodeFrom(record);
+      if (!s.ok()) {
+        break;
+      }
+      if (edit.HasLastSequence() && edit.GetLastSequence() > last_seq) {
+        edit.SetLastSequence(last_seq);
+      }
+      std::string write_record;
+      if (!edit.EncodeTo(&write_record)) {
+        s = Status::Corruption("Unable to Encode VersionEdit");
+        break;
+      }
+      s = file_writer->AddRecord(write_record);
+      if (!s.ok()) {
+        break;
+      }
+    }
+  }
+
+  if (s.ok()) {
+    ImmutableDBOptions imop(db_options);
+    s = SyncManifest(env, &imop, file_writer->file());
+  }
+  file_reader.reset();
+  file_writer.reset();
+  if (s.ok()) {
+    env->DeleteFile(tmp_file);
+  }
+  return s;
+}
+
+Status CheckpointImpl::CreateCheckpointQuick(const std::string& checkpoint_dir,
+                                             uint64_t* checkpoint_decree) {
+  Status s;
+  std::vector<std::string> live_files;
+  uint64_t manifest_file_size = 0;
+  SequenceNumber last_sequence = 0;
+  uint64_t last_decree = 0;
+  bool same_fs = true;
+
+  s = db_->GetEnv()->FileExists(checkpoint_dir);
+  if (s.ok()) {
+    return Status::InvalidArgument("Directory exists");
+  } else if (!s.IsNotFound()) {
+    assert(s.IsIOError());
+    return s;
+  }
+
+  s = db_->DisableFileDeletions();
+  if (s.ok()) {
+    // this will return live_files prefixed with "/"
+    s = db_->GetLiveFilesQuick(live_files, &manifest_file_size, &last_sequence,
+                               &last_decree);
+  }
+  if (!s.ok()) {
+    db_->EnableFileDeletions(false);
+    return s;
+  }
+
+  std::string full_private_path = checkpoint_dir + ".tmp";
+  std::string manifest_file_path;
+  uint64_t manifest_file_number = 0;
+
+  // create snapshot directory
+  s = db_->GetEnv()->CreateDir(full_private_path);
+
+  // copy/hard link live_files
+  for (size_t i = 0; s.ok() && i < live_files.size(); ++i) {
+    uint64_t number;
+    FileType type;
+    bool ok = ParseFileName(live_files[i], &number, &type);
+    if (!ok) {
+      s = Status::Corruption("Can't parse file name. This is very bad");
+      break;
+    }
+    // we should only get sst, manifest, current and options files here
+    assert(type == kTableFile || type == kDescriptorFile ||
+           type == kCurrentFile || type == kOptionsFile);
+    assert(live_files[i].size() > 0 && live_files[i][0] == '/');
+    const std::string& src_fname = live_files[i];
+
+    // do not copy current file because it may have been updated to
+    // point to a new manifest file, so we create it by ourselves
+    if (type == kCurrentFile) {
+      continue;
+    }
+
+    // rules:
+    // * if it's kTableFile, then it's shared
+    // * if it's kDescriptorFile, limit the size to manifest_file_size
+    // * always copy if cross-device link
+    if ((type == kTableFile) && same_fs) {
+      Log(db_->GetOptions().info_log, "Hard Linking %s", src_fname.c_str());
+      s = db_->GetEnv()->LinkFile(db_->GetName() + src_fname,
+                                  full_private_path + src_fname);
+      if (s.IsNotSupported()) {
+        same_fs = false;
+        s = Status::OK();
+      }
+    }
+    if ((type != kTableFile) || (!same_fs)) {
+      Log(db_->GetOptions().info_log, "Copying %s", src_fname.c_str());
+      s = CopyFile(db_->GetEnv(), db_->GetName() + src_fname,
+                   full_private_path + src_fname,
+                   (type == kDescriptorFile) ? manifest_file_size : 0,
+                   false /*use_fsync*/);
+    }
+    if (type == kDescriptorFile) {
+      manifest_file_path = full_private_path + src_fname;
+      manifest_file_number = number;
+    }
+  }
+
+  // we copied all the files, enable file deletions
+  db_->EnableFileDeletions(false);
+
+  if (s.ok()) {
+    // modify manifest file to set correct last_seq in VersionEdit, because
+    // the last_seq recorded in manifest may be greater than the real value
+    assert(!manifest_file_path.empty());
+    s = ModifyManifestFileLastSeq(db_->GetEnv(), db_->GetOptions(),
+                                  manifest_file_path, last_sequence);
+  }
+  if (s.ok()) {
+    // make current file
+    assert(manifest_file_number != 0);
+    s = SetCurrentFile(db_->GetEnv(), full_private_path,
+                       manifest_file_number, nullptr);
+  }
+  if (s.ok()) {
+    // move tmp private backup to real snapshot directory
+    s = db_->GetEnv()->RenameFile(full_private_path, checkpoint_dir);
+  }
+  if (s.ok()) {
+    std::unique_ptr<Directory> checkpoint_directory;
+    db_->GetEnv()->NewDirectory(checkpoint_dir, &checkpoint_directory);
+    if (checkpoint_directory != nullptr) {
+      s = checkpoint_directory->Fsync();
+    }
+  }
+
+  if (!s.ok()) {
+    // clean all the files we might have created
+    Log(db_->GetOptions().info_log, "Snapshot failed -- %s",
+        s.ToString().c_str());
+    // we have to delete the dir and all its children
+    std::vector<std::string> subchildren;
+    db_->GetEnv()->GetChildren(full_private_path, &subchildren);
+    for (auto& subchild : subchildren) {
+      Status s1 = db_->GetEnv()->DeleteFile(full_private_path + subchild);
+      if (s1.ok()) {
+        Log(db_->GetOptions().info_log, "Deleted %s",
+            (full_private_path + subchild).c_str());
+      }
+    }
+    // finally delete the private dir
+    Status s1 = db_->GetEnv()->DeleteDir(full_private_path);
+    Log(db_->GetOptions().info_log, "Deleted dir %s -- %s",
+        full_private_path.c_str(), s1.ToString().c_str());
+    return s;
+  }
+
+  // here we know that we succeeded and installed the new snapshot
+  Log(db_->GetOptions().info_log,
+      "Snapshot DONE. All is good. seqno: %" PRIu64 ", decree: %" PRIu64 "",
+      last_sequence, last_decree);
+
+  if (checkpoint_decree != nullptr) {
+    *checkpoint_decree = last_decree;
+  }
+
+  return s;
+}
+
 }  // namespace rocksdb
 
 #endif  // ROCKSDB_LITE

--- a/utilities/checkpoint/checkpoint_impl.h
+++ b/utilities/checkpoint/checkpoint_impl.h
@@ -57,6 +57,13 @@ class CheckpointImpl : public Checkpoint {
           create_file_cb,
       uint64_t* sequence_number, uint64_t log_size_for_flush);
 
+  // Quickly build an openable snapshot of RocksDB.
+  // Useful when there is only one column family in the RocksDB.
+  using Checkpoint::CreateCheckpointQuick;
+  virtual Status CreateCheckpointQuick(
+      const std::string& checkpoint_dir,
+      /*output*/ uint64_t* checkpoint_decree) override;
+
  private:
   void CleanStagingDirectory(const std::string& path, Logger* info_log);
 


### PR DESCRIPTION
## Changes
- Bump to v6.6.4.
  Since v5.9.2, there are some performance improvements and bugfixes, and also some new features like `atomic_flush` we want to use.
- Apply Pegasus changes.

## Tips

- To review this PR friendly, you could compare this PR with https://github.com/XiaoMi/pegasus-rocksdb/pull/23, which is the version we currently use and contains all the changes we make on rocksdb v5.9.2.

- The failed CI cases should be ignored, cause they are not related with this PR changes, and they are already failed on offical branch [CI](https://travis-ci.org/facebook/rocksdb/builds/644543782?utm_source=github_status&utm_medium=notification)