### PR TITLE
pegasus: remove single cf assert & ignore 0 value decree update

### DIFF
--- a/db/db_filesnapshot.cc
+++ b/db/db_filesnapshot.cc
@@ -172,7 +172,7 @@ Status DBImpl::GetLiveFilesQuick(std::vector<std::string>& ret,
     cfd->current()->GetLastFlushSeqDecree(&seq, &d);
     if (seq > *last_sequence) {
       *last_sequence = seq;
-      // Pegasus decree is only wrote on default column family consistently.
+      // Pegasus decree is only written on default column family consistently.
       if (cfd->GetID() == 0) {
         assert(d >= *last_decree);
         *last_decree = d;

--- a/db/db_filesnapshot.cc
+++ b/db/db_filesnapshot.cc
@@ -159,9 +159,6 @@ Status DBImpl::GetLiveFilesQuick(std::vector<std::string>& ret,
 
   mutex_.Lock();
 
-  // ATTENTION(qinzuoyan): only use default column family.
-  assert(versions_->GetColumnFamilySet()->NumberOfColumnFamilies() == 1u);
-
   // Make a set of all of the live *.sst files
   std::vector<FileDescriptor> live;
   for (auto cfd : *versions_->GetColumnFamilySet()) {
@@ -174,9 +171,12 @@ Status DBImpl::GetLiveFilesQuick(std::vector<std::string>& ret,
     uint64_t d;
     cfd->current()->GetLastFlushSeqDecree(&seq, &d);
     if (seq > *last_sequence) {
-      assert(d >= *last_decree);
       *last_sequence = seq;
-      *last_decree = d;
+      // Pegasus decree is only wrote on default column family consistently.
+      if (cfd->GetID() == 0) {
+        assert(d >= *last_decree);
+        *last_decree = d;
+      }
     }
   }
 

--- a/db/db_impl/db_impl.cc
+++ b/db/db_impl/db_impl.cc
@@ -1275,8 +1275,6 @@ uint64_t DBImpl::GetLastFlushedDecree() const {
   uint64_t d;
 
   mutex_.Lock();
-  // ATTENTION(qinzuoyan): only use default column family.
-  assert(!pegasus_data_ || versions_->GetColumnFamilySet()->NumberOfColumnFamilies() == 1u);
   versions_->GetColumnFamilySet()->GetDefault()->current()->GetLastFlushSeqDecree(&seq, &d);
   mutex_.Unlock();
 

--- a/db/db_impl/db_impl_write.cc
+++ b/db/db_impl/db_impl_write.cc
@@ -100,10 +100,6 @@ Status DBImpl::WriteImpl(const WriteOptions& write_options,
   assert(!WriteBatchInternal::IsLatestPersistentState(my_batch) ||
          disable_memtable);
 
-  // ATTENTION(qinzuoyan): always only use default column family under
-  // replication framework.
-  assert(!pegasus_data_ || single_column_family_mode_);
-
   Status status;
   if (write_options.low_pri) {
     status = ThrottleLowPriWritesIfNeeded(write_options, my_batch);

--- a/db/memtable.h
+++ b/db/memtable.h
@@ -441,9 +441,12 @@ class MemTable {
 
   void UpdateLastSeqDecree(SequenceNumber sequence, uint64_t decree) {
     assert(sequence > last_sequence_); // sequence should not be shared
-    assert(decree >= last_decree_); // decree may be shared
     last_sequence_ = sequence;
-    last_decree_ = decree;
+    // decree of non-default column family would be 0, don't record it
+    if (decree != 0) {
+      assert(decree >= last_decree_); // decree may be shared
+      last_decree_ = decree;
+    }
   }
 
  private:

--- a/db/version_edit.h
+++ b/db/version_edit.h
@@ -311,9 +311,12 @@ class VersionEdit {
 
   void UpdateLastFlushSeqDecree(SequenceNumber sequence, uint64_t decree) {
     if (sequence > last_flush_sequence_) {
-      assert(decree >= last_flush_decree_);
       last_flush_sequence_ = sequence;
-      last_flush_decree_ = decree;
+      // decree of non-default column family would be 0, don't record it
+      if (decree != 0) {
+        assert(decree >= last_flush_decree_);
+        last_flush_decree_ = decree;
+      }
       has_last_flush_seq_decree_ = true;
     }
   }

--- a/db/version_set.h
+++ b/db/version_set.h
@@ -689,9 +689,12 @@ class Version {
 
   void UpdateLastFlushSeqDecreeIfNeeded(SequenceNumber sequence, uint64_t decree) {
     if (sequence > last_flush_sequence_) {
-      assert(decree >= last_flush_decree_);
       last_flush_sequence_ = sequence;
-      last_flush_decree_ = decree;
+      // decree of non-default column family would be 0, don't record it
+      if (decree != 0) {
+        assert(decree >= last_flush_decree_);
+        last_flush_decree_ = decree;
+      }
     }
   }
 
@@ -964,7 +967,6 @@ class VersionSet {
   // Return the last flush sequence number of default column family.
   uint64_t LastFlushSequence() const {
     assert(db_options_->pegasus_data);
-    assert(column_family_set_->NumberOfColumnFamilies() == 1u);
     SequenceNumber seq;
     uint64_t d;
     column_family_set_->GetDefault()->current()->GetLastFlushSeqDecree(&seq, &d);


### PR DESCRIPTION
We are going to store Pegasus meta data into a new column family, so we have to remove asserts which restrict single column family usage. And decree might not set when we write meta data, we should ignore these decree update when decree is 0.