### PR TITLE
fix: the hdfs port not allow zero

### DIFF
--- a/hdfs/env_hdfs.h
+++ b/hdfs/env_hdfs.h
@@ -218,7 +218,7 @@ class HdfsEnv : public Env {
                            remaining.substr(0, rem));
 
     tPort port;
-    port = atoi(portStr.c_str());
+    port = atoi(portStr.c_str());// if you use nameservice, the port need pass 0
     hdfsFS fs = hdfsConnectNewInstance(host.c_str(), port);
     return fs;
   }

--- a/hdfs/env_hdfs.h
+++ b/hdfs/env_hdfs.h
@@ -219,9 +219,6 @@ class HdfsEnv : public Env {
 
     tPort port;
     port = atoi(portStr.c_str());
-    if (port == 0) {
-      throw HdfsFatalException("Bad host-port for hdfs " + uri);
-    }
     hdfsFS fs = hdfsConnectNewInstance(host.c_str(), port);
     return fs;
   }


### PR DESCRIPTION
If use hdfs name service, the port need pass 0, but rocksdb not allow it, this pr fix it 